### PR TITLE
Support Base 3.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,15 @@ jobs:
         - gdb
         - cmake
 
+  - env: BASE=3.14
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - gdb
+        - cmake
+
   - env: BASE=7.0
     compiler: clang
     addons:

--- a/example/ticker.cpp
+++ b/example/ticker.cpp
@@ -8,9 +8,12 @@
  */
 
 #include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include <cstring>
 
 #include <epicsTime.h>
-#include <epicsStdlib.h>
 #include <epicsEvent.h>
 
 #include <pvxs/sharedpv.h>
@@ -31,14 +34,16 @@ int main(int argc, char* argv[])
     }
 
     if(argc>=3) {
-        double rate = 0.0;
-
-        if(epicsParseDouble(argv[2], &rate, nullptr) || rate<=0.0) {
-            std::cerr<<"Rate must be a positive number, not "<<argv[2]<<"\n";
+        try {
+            size_t idx=0;
+            delay = 1.0/std::stod(argv[2], &idx);
+            if(idx<std::strlen(argv[2]))
+                throw std::invalid_argument("Extraneous charactors");
+        }catch(std::exception& e){
+            std::cerr<<"Error parsing rate: "<<e.what()<<"\n";
             return 1;
-        }
 
-        delay = 1.0/rate;
+        }
     }
 
     // Read $PVXS_LOG from process environment and update

--- a/example/ticker.cpp
+++ b/example/ticker.cpp
@@ -85,7 +85,7 @@ int main(int argc, char* argv[])
 
     // connect to SIGINT/SIGTERM to break from main loop
     SigInt handle([&done]() {
-        done.trigger();
+        done.signal();
     });
 
     // Start server in background

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -157,7 +157,7 @@ void ResultWaiter::complete(Result&& result, bool interrupt)
         }
     }
     if(wakeup)
-        notify.trigger();
+        notify.signal();
 }
 
 OperationBase::OperationBase(operation_t op, const std::shared_ptr<Channel>& chan)

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -134,7 +134,7 @@ Config Config::from_env()
 
     if(const char *env = pickenv(&name, {"EPICS_PVAS_SERVER_PORT", "EPICS_PVA_SERVER_PORT"})) {
         try {
-            ret.tcp_port = lexical_cast<unsigned short>(env);
+            ret.tcp_port = parseTo<uint64_t>(env);
         }catch(std::exception& e) {
             log_err_printf(serversetup, "%s invalid integer : %s", name, e.what());
         }
@@ -142,7 +142,7 @@ Config Config::from_env()
 
     if(const char *env = pickenv(&name, {"EPICS_PVAS_BROADCAST_PORT", "EPICS_PVA_BROADCAST_PORT"})) {
         try {
-            ret.udp_port = lexical_cast<unsigned short>(env);
+            ret.udp_port = parseTo<uint64_t>(env);
         }catch(std::exception& e) {
             log_err_printf(serversetup, "%s invalid integer : %s", name, e.what());
         }
@@ -246,7 +246,7 @@ Config Config::from_env()
 
     if(const char *env = pickenv(&name, {"EPICS_PVA_BROADCAST_PORT"})) {
         try {
-            ret.udp_port = lexical_cast<unsigned short>(env);
+            ret.udp_port = parseTo<uint64_t>(env);
         }catch(std::exception& e) {
             log_err_printf(serversetup, "%s invalid integer : %s", name, e.what());
         }

--- a/src/evhelper.cpp
+++ b/src/evhelper.cpp
@@ -129,7 +129,7 @@ struct evbase::Pvt : public epicsThreadRunable
             if(event_add(keepalive.get(), &tick))
                 throw std::runtime_error("Can't start keepalive timer");
 
-            start_sync.trigger();
+            start_sync.signal();
 
             log_info_printf(logerr, "Enter loop worker for %p\n", base.get());
 
@@ -141,7 +141,7 @@ struct evbase::Pvt : public epicsThreadRunable
         }catch(std::exception& e){
             log_exc_printf(logerr, "Unhandled exception in event_base run : %s\n",
                             e.what());
-            start_sync.trigger();
+            start_sync.signal();
         }
     }
 
@@ -165,7 +165,7 @@ struct evbase::Pvt : public epicsThreadRunable
                 }
             }
             if(work.notify)
-                work.notify->trigger();
+                work.notify->signal();
         }
     }
     static

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -28,15 +28,12 @@
 #include <epicsGuard.h>
 #include <epicsTime.h>
 
-#if EPICS_VERSION_INT>=VERSION_INT(3,15,0,0)
-#  include <epicsStackTrace.h>
-#  define USE_STACKTRACE
-#endif
-
 #include "evhelper.h"
 #include "utilpvt.h"
 
-#ifndef USE_STACKTRACE
+#if EPICS_VERSION_INT>=VERSION_INT(3,15,0,0)
+#    include <epicsStackTrace.h>
+#else
 static void epicsStackTrace() {}
 #endif
 

--- a/src/pvxs/log.h
+++ b/src/pvxs/log.h
@@ -8,6 +8,7 @@
 
 #include <atomic>
 
+#include <cstddef>
 #include <stdarg.h>
 
 #include <compilerDependencies.h>

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -7,8 +7,6 @@
 #include <cstring>
 #include <epicsAssert.h>
 
-#include <epicsStdlib.h>
-
 #include "dataimpl.h"
 #include "utilpvt.h"
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -15,8 +15,6 @@
 
 #include <ctype.h>
 
-#include <epicsStdlib.h>
-
 #include <pvxs/util.h>
 #include <pvxs/sharedArray.h>
 #include <pvxs/data.h>
@@ -386,18 +384,35 @@ std::ostream& operator<<(std::ostream& strm, const SockAddr& addr)
 } // namespace pvxs
 
 namespace pvxs {namespace impl {
-namespace idetail {
 
 template<>
-unsigned short as_str<unsigned short>::op(const char *s)
-{
-    epicsUInt16 ret;
-    if(int err = epicsParseUInt16(s, &ret, 0, nullptr)) {
-        (void)err;
-        throw std::runtime_error(SB()<<"Unable to parse as uint16 : "<<s);
-    }
+double parseTo<double>(const std::string& s) {
+    size_t idx=0, L=s.size();
+    double ret = std::stod(s, &idx);
+    for(; idx<L && isspace(s[idx]); idx++) {}
+    if(idx<L)
+        throw std::invalid_argument(SB()<<"Extraneous charactors after double: \""<<escape(s)<<"\"");
     return ret;
 }
+
+template<>
+uint64_t parseTo<uint64_t>(const std::string& s) {
+    size_t idx=0, L=s.size();
+    unsigned long long ret = std::stoull(s, &idx, 0);
+    for(; idx<L && isspace(s[idx]); idx++) {}
+    if(idx<L)
+        throw std::invalid_argument(SB()<<"Extraneous charactors after integer: \""<<escape(s)<<"\"");
+    return ret;
+}
+
+template<>
+int64_t parseTo<int64_t>(const std::string& s) {
+    size_t idx=0, L=s.size();
+    long long ret = std::stoll(s, &idx, 0);
+    for(; idx<L && isspace(s[idx]); idx++) {}
+    if(idx<L)
+        throw std::invalid_argument(SB()<<"Extraneous charactors after unsigned: \""<<escape(s)<<"\"");
+    return ret;
 }
 
 void indent(std::ostream& strm, unsigned level) {

--- a/src/utilpvt.h
+++ b/src/utilpvt.h
@@ -47,24 +47,6 @@ struct SB {
     SB& operator<<(const T& i) { strm<<i; return *this; }
 };
 
-namespace idetail {
-// specific specializations in util.cpp
-template <typename T>
-struct as_str {PVXS_API static T op(const char *s);};
-} // namespace idetail
-
-template <typename T>
-inline T lexical_cast(const char *s)
-{
-    return idetail::as_str<T>::op(s);
-}
-
-template <typename T>
-inline T lexical_cast(const std::string& s)
-{
-    return idetail::as_str<T>::op(s.c_str());
-}
-
 void indent(std::ostream& strm, unsigned level);
 
 namespace idetail {
@@ -99,6 +81,19 @@ constexpr idetail::Range<I> range(I end) { return idetail::Range<I>{I(0), end}; 
 
 template<typename I>
 constexpr idetail::Range<I> range(I begin, I end) { return idetail::Range<I>{begin, end}; }
+
+template<typename T>
+T parseTo(const std::string& s); // not implemented
+
+template<>
+PVXS_API
+double parseTo<double>(const std::string& s);
+template<>
+PVXS_API
+uint64_t parseTo<uint64_t>(const std::string& s);
+template<>
+PVXS_API
+int64_t parseTo<int64_t>(const std::string& s);
 
 #ifdef _WIN32
 #  define RWLOCK_TYPE SRWLOCK

--- a/test/testconfig.cpp
+++ b/test/testconfig.cpp
@@ -39,9 +39,11 @@ void testParse()
         testEq(conf.addressList[1], "5.6.7.8:9876");
     }
 
-    //epicsEnvUnset("EPICS_PVA_ADDR_LIST");
-    //epicsEnvUnset("EPICS_PVA_AUTO_ADDR_LIST");
-    //epicsEnvUnset("EPICS_PVA_BROADCAST_PORT");
+#if EPICS_VERSION_INT>=VERSION_INT(3,15,6,0)
+    epicsEnvUnset("EPICS_PVA_ADDR_LIST");
+    epicsEnvUnset("EPICS_PVA_AUTO_ADDR_LIST");
+    epicsEnvUnset("EPICS_PVA_BROADCAST_PORT");
+#endif
 }
 
 }

--- a/test/testconfig.cpp
+++ b/test/testconfig.cpp
@@ -39,9 +39,9 @@ void testParse()
         testEq(conf.addressList[1], "5.6.7.8:9876");
     }
 
-    epicsEnvUnset("EPICS_PVA_ADDR_LIST");
-    epicsEnvUnset("EPICS_PVA_AUTO_ADDR_LIST");
-    epicsEnvUnset("EPICS_PVA_BROADCAST_PORT");
+    //epicsEnvUnset("EPICS_PVA_ADDR_LIST");
+    //epicsEnvUnset("EPICS_PVA_AUTO_ADDR_LIST");
+    //epicsEnvUnset("EPICS_PVA_BROADCAST_PORT");
 }
 
 }

--- a/test/testget.cpp
+++ b/test/testget.cpp
@@ -73,7 +73,7 @@ struct Tester {
         auto op = cli.get("mailbox")
                 .result([&actual, &done](client::Result&& result) {
                     actual = std::move(result);
-                    done.trigger();
+                    done.signal();
                 })
                 .exec();
 
@@ -140,7 +140,7 @@ struct Tester {
         auto op = cli.info("mailbox")
                 .result([&actual, &done](client::Result&& result) {
                     actual = std::move(result);
-                    done.trigger();
+                    done.signal();
                 })
                 .exec();
 
@@ -162,7 +162,7 @@ struct Tester {
         cli.info("mailbox")
                 .result([&actual, &done](client::Result&& result) {
                     actual = std::move(result);
-                    done.trigger();
+                    done.signal();
                 })
                 .exec();
 
@@ -221,7 +221,7 @@ void testError(bool phase)
     auto op = cli.get("mailbox")
             .result([&actual, &done](client::Result&& result) {
                 actual = std::move(result);
-                done.trigger();
+                done.signal();
             })
             .exec();
 

--- a/test/testinfo.cpp
+++ b/test/testinfo.cpp
@@ -49,7 +49,7 @@ struct Tester {
         auto op = cli.info("mailbox")
                 .result([&actual, &done](client::Result&& result) {
                     actual = std::move(result);
-                    done.trigger();
+                    done.signal();
                 })
                 .exec();
 
@@ -116,7 +116,7 @@ struct Tester {
         auto op = cli.info("mailbox")
                 .result([&actual, &done](client::Result&& result) {
                     actual = std::move(result);
-                    done.trigger();
+                    done.signal();
                 })
                 .exec();
 
@@ -138,7 +138,7 @@ struct Tester {
         cli.info("mailbox")
                 .result([&actual, &done](client::Result&& result) {
                     actual = std::move(result);
-                    done.trigger();
+                    done.signal();
                 })
                 .exec();
 
@@ -183,7 +183,7 @@ void testError()
     auto op = cli.info("mailbox")
             .result([&actual, &done](client::Result&& result) {
                 actual = std::move(result);
-                done.trigger();
+                done.signal();
             })
             .exec();
 

--- a/test/testmon.cpp
+++ b/test/testmon.cpp
@@ -59,7 +59,7 @@ struct BasicTest {
                 .maskDisconnected(false)
                 .event([this](client::Subscription& sub) {
                     testDiag("Event evt");
-                    evt.trigger();
+                    evt.signal();
                 })
                 .exec();
     }
@@ -165,7 +165,7 @@ struct TestLifeCycle : public BasicTest
                         .maskDisconnected(false)
                         .event([&evt2](client::Subscription& sub) {
                             testDiag("Event evt2");
-                            evt2.trigger();
+                            evt2.signal();
                         })
                         .exec();
 

--- a/test/testput.cpp
+++ b/test/testput.cpp
@@ -65,7 +65,7 @@ struct Tester : public TesterBase
                 })
                 .result([&actual, &done](client::Result&& result) {
                     actual = std::move(result);
-                    done.trigger();
+                    done.signal();
                 })
                 .exec();
 
@@ -141,7 +141,7 @@ struct Tester : public TesterBase
         auto op = cli.info("mailbox")
                 .result([&actual, &done](client::Result&& result) {
                     actual = std::move(result);
-                    done.trigger();
+                    done.signal();
                 })
                 .exec();
 
@@ -163,7 +163,7 @@ struct Tester : public TesterBase
         cli.info("mailbox")
                 .result([&actual, &done](client::Result&& result) {
                     actual = std::move(result);
-                    done.trigger();
+                    done.signal();
                 })
                 .exec();
 
@@ -192,7 +192,7 @@ struct TestPutBuilder : public TesterBase
                 .set("nonexistant", "nope", false)
                 .result([&actual, &done](client::Result&& result) {
                     actual = std::move(result);
-                    done.trigger();
+                    done.signal();
                 })
                 .exec();
 
@@ -242,7 +242,7 @@ void testRO()
             })
             .result([&actual, &done](client::Result&& result) {
                 actual = std::move(result);
-                done.trigger();
+                done.signal();
             })
             .exec();
 
@@ -294,7 +294,7 @@ void testError()
     auto op = cli.get("mailbox")
             .result([&actual, &done](client::Result&& result) {
                 actual = std::move(result);
-                done.trigger();
+                done.signal();
             })
             .exec();
 

--- a/test/testrpc.cpp
+++ b/test/testrpc.cpp
@@ -59,7 +59,7 @@ struct Tester {
         auto op = cli.rpc("mailbox", std::move(arg))
                 .result([this](client::Result&& result) {
                     actual = std::move(result);
-                    done.trigger();
+                    done.signal();
                 })
                 .exec();
 

--- a/tools/call.cpp
+++ b/tools/call.cpp
@@ -138,7 +138,7 @@ int main(int argc, char *argv[])
                 std::cerr<<"Error "<<typeid(e).name()<<" : "<<e.what()<<"\n";
                 ret=1;
             }
-            done.trigger();
+            done.signal();
         })
                 .exec();
 

--- a/tools/call.cpp
+++ b/tools/call.cpp
@@ -10,7 +10,6 @@
 #include <atomic>
 
 #include <epicsVersion.h>
-#include <epicsStdlib.h>
 #include <epicsGetopt.h>
 #include <epicsThread.h>
 
@@ -27,12 +26,12 @@ namespace {
 void usage(const char* argv0)
 {
     std::cerr<<"Usage: "<<argv0<<" <opts> <pvname> <fld>=<value> ...\n"
-               "\n"
-               "  -h        Show this message.\n"
-               "  -V        Print version and exit.\n"
-               "  -v        Make more noise.\n"
-               "  -d        Shorthand for $PVXS_LOG=\"pvxs.*=DEBUG\".  Make a lot of noise.\n"
-               "  -w <sec>  Operation timeout in seconds.  default 5 sec.\n"
+                                 "\n"
+                                 "  -h        Show this message.\n"
+                                 "  -V        Print version and exit.\n"
+                                 "  -v        Make more noise.\n"
+                                 "  -d        Shorthand for $PVXS_LOG=\"pvxs.*=DEBUG\".  Make a lot of noise.\n"
+                                 "  -w <sec>  Operation timeout in seconds.  default 5 sec.\n"
                ;
 }
 
@@ -40,122 +39,124 @@ void usage(const char* argv0)
 
 int main(int argc, char *argv[])
 {
-    logger_config_env(); // from $PVXS_LOG
-    double timeout = 5.0;
-    bool verbose = false;
+    try {
+        logger_config_env(); // from $PVXS_LOG
+        double timeout = 5.0;
+        bool verbose = false;
 
-    {
-        int opt;
-        while ((opt = getopt(argc, argv, "hVvdw:")) != -1) {
-            switch(opt) {
-            case 'h':
-                usage(argv[0]);
-                return 0;
-            case 'V':
-                std::cout<<version_str()<<"\n";
-                std::cout<<EPICS_VERSION_STRING<<"\n";
-                std::cout<<"libevent "<<event_get_version()<<"\n";
-                return 0;
-            case 'v':
-                verbose = true;
-                break;
-            case 'd':
-                logger_level_set("pvxs.*", Level::Debug);
-                break;
-            case 'w':
-                if(epicsParseDouble(optarg, &timeout, nullptr)) {
-                    std::cerr<<"Invalid timeout value: "<<optarg<<"\n";
+        {
+            int opt;
+            while ((opt = getopt(argc, argv, "hVvdw:")) != -1) {
+                switch(opt) {
+                case 'h':
+                    usage(argv[0]);
+                    return 0;
+                case 'V':
+                    std::cout<<version_str()<<"\n";
+                    std::cout<<EPICS_VERSION_STRING<<"\n";
+                    std::cout<<"libevent "<<event_get_version()<<"\n";
+                    return 0;
+                case 'v':
+                    verbose = true;
+                    break;
+                case 'd':
+                    logger_level_set("pvxs.*", Level::Debug);
+                    break;
+                case 'w':
+                    timeout = parseTo<double>(optarg);
+                    break;
+                default:
+                    usage(argv[0]);
+                    std::cerr<<"\nUnknown argument: "<<char(opt)<<std::endl;
                     return 1;
                 }
-                break;
-            default:
-                usage(argv[0]);
-                std::cerr<<"\nUnknown argument: "<<char(opt)<<std::endl;
-                return 1;
             }
         }
-    }
 
-    if(optind==argc) {
-        usage(argv[0]);
-        std::cerr<<"\nExpected PV name\n";
-        return 1;
-    }
-
-    std::string pvname(argv[optind++]);
-    std::list<std::string> keys;
-    std::map<std::string, std::string> values;
-
-    for(auto n : range(optind, argc)) {
-        std::string fv(argv[n]);
-        auto sep = fv.find_first_of('=');
-
-        if(sep==std::string::npos) {
-            std::cerr<<"Error: expected <fld>=<value> not \""<<escape(fv)<<"\"\n";
+        if(optind==argc) {
+            usage(argv[0]);
+            std::cerr<<"\nExpected PV name\n";
             return 1;
         }
 
-        auto key(fv.substr(0, sep));
+        std::string pvname(argv[optind++]);
+        std::list<std::string> keys;
+        std::map<std::string, std::string> values;
 
-        if(values.find(key)!=values.end()) {
-            std::cerr<<"Error: duplicate argument name "<<key<<"\n";
-            return 1;
+        for(auto n : range(optind, argc)) {
+            std::string fv(argv[n]);
+            auto sep = fv.find_first_of('=');
+
+            if(sep==std::string::npos) {
+                std::cerr<<"Error: expected <fld>=<value> not \""<<escape(fv)<<"\"\n";
+                return 1;
+            }
+
+            auto key(fv.substr(0, sep));
+
+            if(values.find(key)!=values.end()) {
+                std::cerr<<"Error: duplicate argument name "<<key<<"\n";
+                return 1;
+            }
+
+            values[key] = fv.substr(sep+1);
+            keys.push_back(key);
         }
 
-        values[key] = fv.substr(sep+1);
-        keys.push_back(key);
-    }
+        auto uri = nt::NTURI({}).build();
 
-    auto uri = nt::NTURI({}).build();
+        for(auto& key : keys) {
+            using namespace pvxs::members;
 
-    for(auto& key : keys) {
-        using namespace pvxs::members;
+            uri += {Struct("query", {String(key)})};
+        }
 
-        uri += {Struct("query", {String(key)})};
-    }
+        auto arg = uri.create();
+        arg["path"] = pvname;
+        auto query = arg["query"];
 
-    auto arg = uri.create();
-    arg["path"] = pvname;
-    auto query = arg["query"];
+        for(auto& pair : values) {
+            query[pair.first] = pair.second;
+        }
 
-    for(auto& pair : values) {
-        query[pair.first] = pair.second;
-    }
+        auto ctxt = client::Config::from_env().build();
 
-    auto ctxt = client::Config::from_env().build();
+        if(verbose)
+            std::cout<<"Effective config\n"<<ctxt.config();
 
-    if(verbose)
-        std::cout<<"Effective config\n"<<ctxt.config();
+        epicsEvent done;
+        int ret=2;
 
-    epicsEvent done;
-    int ret=2;
+        auto op =ctxt.rpc(pvname, std::move(arg))
+                     .result([&ret, &done](client::Result&& result) {
+            try {
+                auto val = result();
+                if(val)
+                    std::cout<<val;
+                ret=0;
+            }catch(std::exception& e){
+                std::cerr<<"Error "<<typeid(e).name()<<" : "<<e.what()<<"\n";
+                ret=1;
+            }
+            done.trigger();
+        })
+                .exec();
 
-    auto op =ctxt.rpc(pvname, std::move(arg))
-            .result([&ret, &done](client::Result&& result) {
-                try {
-                    auto val = result();
-                    if(val)
-                        std::cout<<val;
-                    ret=0;
-                }catch(std::exception& e){
-                    std::cerr<<"Error "<<typeid(e).name()<<" : "<<e.what()<<"\n";
-                    ret=1;
-                }
-                done.trigger();
-            })
-            .exec();
+        // expedite search after starting all requests
+        ctxt.hurryUp();
 
-    // expedite search after starting all requests
-    ctxt.hurryUp();
+        SigInt sig([&done]() {
+            done.signal();
+        });
 
-    SigInt sig([&done]() {
-        done.signal();
-    });
-
-    if(!done.wait(timeout)) {
-        std::cerr<<"Timeout\n";
+        if(!done.wait(timeout)) {
+            std::cerr<<"Timeout\n";
+            return 1;
+        } else {
+            return ret;
+        }
+    }catch(std::exception& e){
+        std::cerr<<"Error: "<<e.what()<<"\n";
         return 1;
-    } else {
-        return ret;
     }
 }

--- a/tools/get.cpp
+++ b/tools/get.cpp
@@ -11,7 +11,6 @@
 #include <cstring>
 
 #include <epicsVersion.h>
-#include <epicsStdlib.h>
 #include <epicsGetopt.h>
 #include <epicsThread.h>
 
@@ -45,104 +44,103 @@ void usage(const char* argv0)
 
 int main(int argc, char *argv[])
 {
-    logger_config_env(); // from $PVXS_LOG
-    double timeout = 5.0;
-    bool verbose = false;
-    std::string request;
-    Value::Fmt::format_t format = Value::Fmt::Delta;
-    auto arrLimit = epicsUInt64(-1);
+    try {
+        logger_config_env(); // from $PVXS_LOG
+        double timeout = 5.0;
+        bool verbose = false;
+        std::string request;
+        Value::Fmt::format_t format = Value::Fmt::Delta;
+        auto arrLimit = uint64_t(-1);
 
-    {
-        int opt;
-        while ((opt = getopt(argc, argv, "hVvdw:r:#:F:")) != -1) {
-            switch(opt) {
-            case 'h':
-                usage(argv[0]);
-                return 0;
-            case 'V':
-                std::cout<<version_str()<<"\n";
-                std::cout<<EPICS_VERSION_STRING<<"\n";
-                std::cout<<"libevent "<<event_get_version()<<"\n";
-                return 0;
-            case 'v':
-                verbose = true;
-                break;
-            case 'd':
-                logger_level_set("pvxs.*", Level::Debug);
-                break;
-            case 'w':
-                if(epicsParseDouble(optarg, &timeout, nullptr)) {
-                    std::cerr<<"Invalid timeout value: "<<optarg<<"\n";
+        {
+            int opt;
+            while ((opt = getopt(argc, argv, "hVvdw:r:#:F:")) != -1) {
+                switch(opt) {
+                case 'h':
+                    usage(argv[0]);
+                    return 0;
+                case 'V':
+                    std::cout<<version_str()<<"\n";
+                    std::cout<<EPICS_VERSION_STRING<<"\n";
+                    std::cout<<"libevent "<<event_get_version()<<"\n";
+                    return 0;
+                case 'v':
+                    verbose = true;
+                    break;
+                case 'd':
+                    logger_level_set("pvxs.*", Level::Debug);
+                    break;
+                case 'w':
+                    timeout = parseTo<double>(optarg);
+                    break;
+                case 'r':
+                    request = optarg;
+                    break;
+                case '#':
+                    arrLimit = parseTo<uint64_t>(optarg);
+                    break;
+                case 'F':
+                    if(std::strcmp(optarg, "tree")==0) {
+                        format = Value::Fmt::Tree;
+                    } else if(std::strcmp(optarg, "delta")==0) {
+                        format = Value::Fmt::Delta;
+                    } else {
+                        std::cerr<<"Warning: ignoring unknown format '"<<optarg<<"'\n";
+                    }
+                    break;
+                default:
+                    usage(argv[0]);
+                    std::cerr<<"\nUnknown argument: "<<char(opt)<<std::endl;
                     return 1;
                 }
-                break;
-            case 'r':
-                request = optarg;
-                break;
-            case '#':
-                if(epicsParseUInt64(optarg, &arrLimit, 0, nullptr)) {
-                    std::cerr<<"Invalid array limit: "<<optarg<<"\n";
-                    return 1;
-                }
-                break;
-            case 'F':
-                if(std::strcmp(optarg, "tree")==0) {
-                    format = Value::Fmt::Tree;
-                } else if(std::strcmp(optarg, "delta")==0) {
-                    format = Value::Fmt::Delta;
-                } else {
-                    std::cerr<<"Warning: ignoring unknown format '"<<optarg<<"'\n";
-                }
-                break;
-            default:
-                usage(argv[0]);
-                std::cerr<<"\nUnknown argument: "<<char(opt)<<std::endl;
-                return 1;
             }
         }
-    }
 
-    auto ctxt = client::Config::from_env().build();
+        auto ctxt = client::Config::from_env().build();
 
-    if(verbose)
-        std::cout<<"Effective config\n"<<ctxt.config();
-
-    std::list<std::shared_ptr<client::Operation>> ops;
-
-    std::atomic<int> remaining{argc-optind};
-    epicsEvent done;
-
-    for(auto n : range(optind, argc)) {
-
-        ops.push_back(ctxt.get(argv[n])
-                      .pvRequest(request)
-                      .result([&argv, n, &remaining, &done, format, arrLimit](client::Result&& result) {
-                          std::cout<<argv[n]<<"\n"<<result()
-                                     .format()
-                                     .format(format)
-                                     .arrayLimit(arrLimit);
-
-                          if(remaining.fetch_sub(1)==1)
-                              done.trigger();
-                      })
-                      .exec());
-    }
-
-    // expedite search after starting all requests
-    ctxt.hurryUp();
-
-    SigInt sig([&done]() {
-        done.signal();
-    });
-
-    if(!done.wait(timeout)) {
-        std::cerr<<"Timeout\n";
-        return 1;
-    } else if(remaining.load()==0u) {
-        return 0;
-    } else {
         if(verbose)
-            std::cerr<<"Interrupted\n";
-        return 2;
+            std::cout<<"Effective config\n"<<ctxt.config();
+
+        std::list<std::shared_ptr<client::Operation>> ops;
+
+        std::atomic<int> remaining{argc-optind};
+        epicsEvent done;
+
+        for(auto n : range(optind, argc)) {
+
+            ops.push_back(ctxt.get(argv[n])
+                          .pvRequest(request)
+                          .result([&argv, n, &remaining, &done, format, arrLimit](client::Result&& result) {
+                              std::cout<<argv[n]<<"\n"<<result()
+                                         .format()
+                                         .format(format)
+                                         .arrayLimit(arrLimit);
+
+                              if(remaining.fetch_sub(1)==1)
+                                  done.trigger();
+                          })
+                          .exec());
+        }
+
+        // expedite search after starting all requests
+        ctxt.hurryUp();
+
+        SigInt sig([&done]() {
+            done.signal();
+        });
+
+        if(!done.wait(timeout)) {
+            std::cerr<<"Timeout\n";
+            return 1;
+        } else if(remaining.load()==0u) {
+            return 0;
+        } else {
+            if(verbose)
+                std::cerr<<"Interrupted\n";
+            return 2;
+        }
+    }catch(std::exception& e){
+        std::cerr<<"Error: "<<e.what()<<"\n";
+        return 1;
     }
 }

--- a/tools/get.cpp
+++ b/tools/get.cpp
@@ -117,7 +117,7 @@ int main(int argc, char *argv[])
                                          .arrayLimit(arrLimit);
 
                               if(remaining.fetch_sub(1)==1)
-                                  done.trigger();
+                                  done.signal();
                           })
                           .exec());
         }

--- a/tools/info.cpp
+++ b/tools/info.cpp
@@ -9,7 +9,6 @@
 #include <atomic>
 
 #include <epicsVersion.h>
-#include <epicsStdlib.h>
 #include <epicsGetopt.h>
 #include <epicsThread.h>
 
@@ -38,86 +37,88 @@ void usage(const char* argv0)
 
 int main(int argc, char *argv[])
 {
-    logger_config_env(); // from $PVXS_LOG
-    double timeout = 5.0;
-    bool verbose = false;
+    try {
+        logger_config_env(); // from $PVXS_LOG
+        double timeout = 5.0;
+        bool verbose = false;
 
-    {
-        int opt;
-        while ((opt = getopt(argc, argv, "hVvdw:")) != -1) {
-            switch(opt) {
-            case 'h':
-                usage(argv[0]);
-                return 0;
-            case 'V':
-                std::cout<<version_str()<<"\n";
-                std::cout<<EPICS_VERSION_STRING<<"\n";
-                std::cout<<"libevent "<<event_get_version()<<"\n";
-                return 0;
-            case 'v':
-                verbose = true;
-                break;
-            case 'd':
-                logger_level_set("pvxs.*", Level::Debug);
-                break;
-            case 'w':
-                if(epicsParseDouble(optarg, &timeout, nullptr)) {
-                    std::cerr<<"Invalid timeout value: "<<optarg<<"\n";
+        {
+            int opt;
+            while ((opt = getopt(argc, argv, "hVvdw:")) != -1) {
+                switch(opt) {
+                case 'h':
+                    usage(argv[0]);
+                    return 0;
+                case 'V':
+                    std::cout<<version_str()<<"\n";
+                    std::cout<<EPICS_VERSION_STRING<<"\n";
+                    std::cout<<"libevent "<<event_get_version()<<"\n";
+                    return 0;
+                case 'v':
+                    verbose = true;
+                    break;
+                case 'd':
+                    logger_level_set("pvxs.*", Level::Debug);
+                    break;
+                case 'w':
+                    timeout = parseTo<double>(optarg);
+                    break;
+                default:
+                    usage(argv[0]);
+                    std::cerr<<"\nUnknown argument: "<<char(opt)<<std::endl;
                     return 1;
                 }
-                break;
-            default:
-                usage(argv[0]);
-                std::cerr<<"\nUnknown argument: "<<char(opt)<<std::endl;
-                return 1;
             }
         }
-    }
 
-    auto ctxt = client::Config::from_env().build();
+        auto ctxt = client::Config::from_env().build();
 
-    if(verbose)
-        std::cout<<"Effective config\n"<<ctxt.config();
-
-    std::list<std::shared_ptr<client::Operation>> ops;
-
-    std::atomic<int> remaining{argc-optind};
-    epicsEvent done;
-
-    for(auto n : range(optind, argc)) {
-
-        ops.push_back(ctxt.info(argv[n])
-                      .result([&argv, n, &remaining, &done](client::Result&& result) {
-                          std::cout<<argv[n];
-                          try {
-                              std::cout<<" from "<<result.peerName()<<"\n"<<result()
-                                         .format()
-                                         .showValue(false);
-                          }catch(std::exception& e){
-                              std::cout<<" Error: "<<e.what()<<"\n";
-                          }
-
-                          if(remaining.fetch_sub(1)==1)
-                              done.trigger();
-                      })
-                      .exec());
-    }
-
-    // expedite search after starting all requests
-    ctxt.hurryUp();
-
-    SigInt sig([&done]() {
-        done.signal();
-    });
-
-    if(!done.wait(timeout)) {
-        std::cerr<<"Timeout\n";
-        return 1;
-    } else if(remaining.load()==0u) {
-        return 0;
-    } else {
         if(verbose)
-            std::cerr<<"Interrupted\n";
-        return 2;
+            std::cout<<"Effective config\n"<<ctxt.config();
+
+        std::list<std::shared_ptr<client::Operation>> ops;
+
+        std::atomic<int> remaining{argc-optind};
+        epicsEvent done;
+
+        for(auto n : range(optind, argc)) {
+
+            ops.push_back(ctxt.info(argv[n])
+                          .result([&argv, n, &remaining, &done](client::Result&& result) {
+                              std::cout<<argv[n];
+                              try {
+                                  std::cout<<" from "<<result.peerName()<<"\n"<<result()
+                                             .format()
+                                             .showValue(false);
+                              }catch(std::exception& e){
+                                  std::cout<<" Error: "<<e.what()<<"\n";
+                              }
+
+                              if(remaining.fetch_sub(1)==1)
+                                  done.trigger();
+                          })
+                          .exec());
+        }
+
+        // expedite search after starting all requests
+        ctxt.hurryUp();
+
+        SigInt sig([&done]() {
+            done.signal();
+        });
+
+        if(!done.wait(timeout)) {
+            std::cerr<<"Timeout\n";
+            return 1;
+        } else if(remaining.load()==0u) {
+            return 0;
+        } else {
+            if(verbose)
+                std::cerr<<"Interrupted\n";
+            return 2;
+        }
+    }catch(std::exception& e){
+        std::cerr<<"Error: "<<e.what()<<"\n";
+        return 1;
     }
 }

--- a/tools/info.cpp
+++ b/tools/info.cpp
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
                               }
 
                               if(remaining.fetch_sub(1)==1)
-                                  done.trigger();
+                                  done.signal();
                           })
                           .exec());
         }

--- a/tools/monitor.cpp
+++ b/tools/monitor.cpp
@@ -125,7 +125,7 @@ int main(int argc, char *argv[])
                     if(verbose)
                         std::cerr<<argv[n]<<" Finished\n";
                     if(remaining.fetch_sub(1)==1)
-                        done.trigger();
+                        done.signal();
 
                 }catch(client::Connected& conn) {
                     std::cerr<<argv[n]<<" Connected to "<<conn.peerName<<"\n";

--- a/tools/put.cpp
+++ b/tools/put.cpp
@@ -134,7 +134,7 @@ int main(int argc, char *argv[])
                         std::cerr<<"Error "<<typeid(e).name()<<" : "<<e.what()<<"\n";
                         ret=1;
                     }
-                    done.trigger();
+                    done.signal();
                 })
                 .exec();
 

--- a/tools/put.cpp
+++ b/tools/put.cpp
@@ -9,7 +9,6 @@
 #include <atomic>
 
 #include <epicsVersion.h>
-#include <epicsStdlib.h>
 #include <epicsGetopt.h>
 #include <epicsThread.h>
 
@@ -39,119 +38,121 @@ void usage(const char* argv0)
 
 int main(int argc, char *argv[])
 {
-    logger_config_env(); // from $PVXS_LOG
-    double timeout = 5.0;
-    bool verbose = false;
-    std::string request;
+    try {
+        logger_config_env(); // from $PVXS_LOG
+        double timeout = 5.0;
+        bool verbose = false;
+        std::string request;
 
-    {
-        int opt;
-        while ((opt = getopt(argc, argv, "hvVdw:r:")) != -1) {
-            switch(opt) {
-            case 'h':
-                usage(argv[0]);
-                return 0;
-            case 'V':
-                std::cout<<version_str()<<"\n";
-                std::cout<<EPICS_VERSION_STRING<<"\n";
-                std::cout<<"libevent "<<event_get_version()<<"\n";
-                return 0;
-            case 'v':
-                verbose = true;
-                break;
-            case 'd':
-                logger_level_set("pvxs.*", Level::Debug);
-                break;
-            case 'w':
-                if(epicsParseDouble(optarg, &timeout, nullptr)) {
-                    std::cerr<<"Invalid timeout value: "<<optarg<<"\n";
+        {
+            int opt;
+            while ((opt = getopt(argc, argv, "hvVdw:r:")) != -1) {
+                switch(opt) {
+                case 'h':
+                    usage(argv[0]);
+                    return 0;
+                case 'V':
+                    std::cout<<version_str()<<"\n";
+                    std::cout<<EPICS_VERSION_STRING<<"\n";
+                    std::cout<<"libevent "<<event_get_version()<<"\n";
+                    return 0;
+                case 'v':
+                    verbose = true;
+                    break;
+                case 'd':
+                    logger_level_set("pvxs.*", Level::Debug);
+                    break;
+                case 'w':
+                    timeout = parseTo<double>(optarg);
+                    break;
+                case 'r':
+                    request = optarg;
+                    break;
+                default:
+                    usage(argv[0]);
+                    std::cerr<<"\nUnknown argument: "<<char(opt)<<std::endl;
                     return 1;
                 }
-                break;
-            case 'r':
-                request = optarg;
-                break;
-            default:
-                usage(argv[0]);
-                std::cerr<<"\nUnknown argument: "<<char(opt)<<std::endl;
-                return 1;
             }
         }
-    }
 
-    if(optind==argc) {
-        usage(argv[0]);
-        std::cerr<<"\nExpected PV name\n";
-        return 1;
-    }
-
-    std::string pvname(argv[optind++]);
-    std::map<std::string, std::string> values;
-
-    if(argc-optind==1 && std::string(argv[optind]).find_first_of('=')==std::string::npos) {
-        // only one field assignment, and field name omitted.
-        // implies .value
-
-        values["value"] = argv[optind];
-
-    } else {
-        for(auto n : range(optind, argc)) {
-            std::string fv(argv[n]);
-            auto sep = fv.find_first_of('=');
-
-            if(sep==std::string::npos) {
-                std::cerr<<"Error: expected <fld>=<value> not \""<<escape(fv)<<"\"\n";
-                return 1;
-            }
-
-            values[fv.substr(0, sep)] = fv.substr(sep+1);
+        if(optind==argc) {
+            usage(argv[0]);
+            std::cerr<<"\nExpected PV name\n";
+            return 1;
         }
-    }
+
+        std::string pvname(argv[optind++]);
+        std::map<std::string, std::string> values;
+
+        if(argc-optind==1 && std::string(argv[optind]).find_first_of('=')==std::string::npos) {
+            // only one field assignment, and field name omitted.
+            // implies .value
+
+            values["value"] = argv[optind];
+
+        } else {
+            for(auto n : range(optind, argc)) {
+                std::string fv(argv[n]);
+                auto sep = fv.find_first_of('=');
+
+                if(sep==std::string::npos) {
+                    std::cerr<<"Error: expected <fld>=<value> not \""<<escape(fv)<<"\"\n";
+                    return 1;
+                }
+
+                values[fv.substr(0, sep)] = fv.substr(sep+1);
+            }
+        }
 
 
-    auto ctxt = client::Config::from_env().build();
+        auto ctxt = client::Config::from_env().build();
 
-    if(verbose)
-        std::cout<<"Effective config\n"<<ctxt.config();
+        if(verbose)
+            std::cout<<"Effective config\n"<<ctxt.config();
 
-    epicsEvent done;
-    int ret=0;
+        epicsEvent done;
+        int ret=0;
 
-    auto op =ctxt.put(pvname)
-            .pvRequest(request)
-            .build([&values](Value&& prototype) -> Value {
-                auto val = std::move(prototype);
-                for(auto& pair : values) {
-                    try{
-                        val[pair.first] = pair.second;
-                    }catch(NoConvert& e){
-                        throw std::runtime_error(SB()<<"Unable to assign "<<pair.first<<" from \""<<escape(pair.second)<<"\"");
+        auto op =ctxt.put(pvname)
+                .pvRequest(request)
+                .build([&values](Value&& prototype) -> Value {
+                    auto val = std::move(prototype);
+                    for(auto& pair : values) {
+                        try{
+                            val[pair.first] = pair.second;
+                        }catch(NoConvert& e){
+                            throw std::runtime_error(SB()<<"Unable to assign "<<pair.first<<" from \""<<escape(pair.second)<<"\"");
+                        }
                     }
-                }
-                return val;
-            })
-            .result([&ret, &done](client::Result&& result) {
-                try {
-                    result();
-                }catch(std::exception& e){
-                    std::cerr<<"Error "<<typeid(e).name()<<" : "<<e.what()<<"\n";
-                    ret=1;
-                }
-                done.trigger();
-            })
-            .exec();
+                    return val;
+                })
+                .result([&ret, &done](client::Result&& result) {
+                    try {
+                        result();
+                    }catch(std::exception& e){
+                        std::cerr<<"Error "<<typeid(e).name()<<" : "<<e.what()<<"\n";
+                        ret=1;
+                    }
+                    done.trigger();
+                })
+                .exec();
 
-    // expedite search after starting all requests
-    ctxt.hurryUp();
+        // expedite search after starting all requests
+        ctxt.hurryUp();
 
-    SigInt sig([&done]() {
-        done.signal();
-    });
+        SigInt sig([&done]() {
+            done.signal();
+        });
 
-    if(!done.wait(timeout)) {
-        std::cerr<<"Timeout\n";
+        if(!done.wait(timeout)) {
+            std::cerr<<"Timeout\n";
+            return 1;
+        } else {
+            return ret;
+        }
+    }catch(std::exception& e){
+        std::cerr<<"Error: "<<e.what()<<"\n";
         return 1;
-    } else {
-        return ret;
     }
 }

--- a/tools/pvxvct.cpp
+++ b/tools/pvxvct.cpp
@@ -254,7 +254,7 @@ int main(int argc, char *argv[])
 
         epicsEvent done;
         pva::SigInt handle([&done](){
-            done.trigger();
+            done.signal();
         });
 
         done.wait();


### PR DESCRIPTION
Builds on #3, mostly to remove use of `epicsParse*()` family of functions in favor of `std::sto*()`.  Changes to tools/ best viewed with ignore whitespace.

@klemenv