### PR TITLE
Add client channel cache

### DIFF
--- a/src/pvxs/client.h
+++ b/src/pvxs/client.h
@@ -358,6 +358,10 @@ public:
      */
     void hurryUp();
 
+    /** Immediately close unused channels and connections.
+     */
+    void cacheClear();
+
     explicit operator bool() const { return pvt.operator bool(); }
     size_t use_count() const { return pvt.use_count(); }
 private:

--- a/test/testget.cpp
+++ b/test/testget.cpp
@@ -84,6 +84,9 @@ struct Tester {
         } else {
             testSkip(1, "timeout");
         }
+
+        op.reset();
+        cli.cacheClear();
     }
 
     void loopback()

--- a/test/testinfo.cpp
+++ b/test/testinfo.cpp
@@ -60,6 +60,9 @@ struct Tester {
         } else {
             testSkip(1, "timeout");
         }
+
+        op.reset();
+        cli.cacheClear();
     }
 
     void loopback()

--- a/test/testput.cpp
+++ b/test/testput.cpp
@@ -85,6 +85,9 @@ struct Tester : public TesterBase
         } else {
             testSkip(2, "timeout");
         }
+
+        op.reset();
+        cli.cacheClear();
     }
 
     void loopback(bool get)


### PR DESCRIPTION
Maintain unused channels for 20 seconds before closing.

Uses mark+sweep style garbage collection to flag and then drop client channels which are not referenced by an operation.

This requires creating a shared_ptr reference loop between `Context::Pvt` (the internal reference) and `Channel`.  This loop is explicitly broken by `Context::Pvt::close()` (the external reference dtor) as well as the new `Context::cacheClean()` and the timer callback `Context::Pvt::cacheClean()`.