### PR TITLE
Work in progress (w/ API changes)

### DIFF
--- a/documentation/client.rst
+++ b/documentation/client.rst
@@ -12,7 +12,7 @@ Configuration
 -------------
 
 The recommended starting point is creating new context configured from $PVA_* environment variables.
-Use `pvxs::server::Config::from_env` and then `pvxs::server::Config::build`.
+Use `pvxs::server::Config::fromEnv` and then `pvxs::server::Config::build`.
 
 EPICS_PVA_ADDR_LIST
     A list of destination addresses to which UDP search messages will be sent.
@@ -29,7 +29,7 @@ EPICS_PVA_BROADCAST_PORT
 
     using namespace pvxs;
     // Context configured from process environment
-    client::Context ctxt = client::Config::from_env().build();
+    client::Context ctxt = client::Config::fromEnv().build();
 
 Programatic configuration can be accomplished by explicitly filling in a `pvxs::server::Config`.
 

--- a/documentation/server.rst
+++ b/documentation/server.rst
@@ -19,7 +19,7 @@ The basic recipe to run a server using configuration from the process environmen
 
 .. code-block:: c++
 
-    auto serv = server::Config::from_env()
+    auto serv = server::Config::fromEnv()
                 .build()
     // call serv.addSource() at least once
     serv.run(); // run intil SIGINT or serv.interrupt()
@@ -35,7 +35,7 @@ provide/claim a given PV name, the Source with the lowest "order" will win.
 Configuration
 -------------
 
-The recommended starting point when configuring a Server is `pvxs::server::Config::from_env`
+The recommended starting point when configuring a Server is `pvxs::server::Config::fromEnv`
 which will use the following environment variables when set.
 
 Entries naming multiple environment variables will prefer the left most which is set.

--- a/documentation/sharedpv.rst
+++ b/documentation/sharedpv.rst
@@ -28,7 +28,7 @@ A simple usage is:
 
     src.add(argv[1], pv);
 
-    auto serv = server::Server::Config::from_env()
+    auto serv = server::Server::Config::fromEnv()
             .build()
             .addSource("box", src.source());
 

--- a/documentation/value.rst
+++ b/documentation/value.rst
@@ -72,6 +72,17 @@ All operations on an invalid Value should be safe and well defined.
 In this example, the operator[] lookup of a non-existant field returns an invalid Value.
 Attempting to extract an integer from this will then throw a `pvxs::NoField` exception.
 
+Value
+-----
+
+Field Lookup
+^^^^^^^^^^^^
+
+Access to members of structured types is accomplished through `pvxs::Value::operator[]` or `pvxs::Value::lookup`.
+These two methods differ in how errors are communicated.
+operator[] will return an "invalid" or "empty" Value if the expression does not address a member.
+lookup() will throw an exception describing where and how expression evaluation failed.
+
 Iteration
 ^^^^^^^^^
 
@@ -102,6 +113,8 @@ and will always appear as empty.
 .. doxygenstruct:: pvxs::NoField
 
 .. doxygenstruct:: pvxs::NoConvert
+
+.. doxygenstruct:: pvxs::LookupError
 
 Array fields
 ------------

--- a/documentation/value.rst
+++ b/documentation/value.rst
@@ -13,12 +13,14 @@ Value Container
     #include <pvxs/data.h>
     namespace pvxs { ... }
 
+`pvxs::Value` is the primary data container type used with PVXS.
 A `pvxs::Value` may be obtained via the remote peer (client or server),
 or created locally.  See `ntapi` or `typedefapi`.
 
-`pvxs::Value` is a pointer-like object which, maybe, references
+`pvxs::Value` is a safe pointer-like object which, maybe, references
 a node in a tree of sub-structures and leaf fields.
-This tree is called a Sturture as it behaves in many ways like a C 'struct'.
+This tree will be referred to as a Structure as it behaves
+in many ways like a C 'struct'.
 
 For example, the following code:
 
@@ -51,7 +53,7 @@ Is analogous to the following pseudo code.
 With the chief functional difference being that the analogs of the casts are made safe.
 Also, the storage of the underlying Structure will be free'd when no more Values reference it.
 
-A Value which does not reference any underlying Structure is not valid.
+A Value which does not reference any underlying Structure is not valid, or "empty".
 
 .. code-block:: c++
 
@@ -69,6 +71,30 @@ All operations on an invalid Value should be safe and well defined.
 
 In this example, the operator[] lookup of a non-existant field returns an invalid Value.
 Attempting to extract an integer from this will then throw a `pvxs::NoField` exception.
+
+Iteration
+^^^^^^^^^
+
+`pvxs::Value` instances pointing to a non-array structured data field (Struct or Union)
+may be iterated.  Iteration comes in three variations: `pvxs::Value::iall`, `pvxs::Value::ichildren`,
+and `pvxs::Value::imarked`.
+
+For a Struct, iall() is a depth first traversal of all fields.
+ichildren() traverses all child fields (excluding eg. grandchildren
+and further).  imarked() considers all fields, but only visits
+those which have beem marked (`pvxs::Value::isMarked`).
+
+For a Union.  iall() and ichildren() are identical, and will
+visit all possible Union members, excluding the implicit NULL member.
+Traversal does not effect member selection.
+imarked() for a Union will visit at most one member (if one is selected)>
+
+Iteration of Union may return Value instances
+allocated with temporary storage.  Changes to these instances
+will not effect the underlying structure.
+
+Iteration of other field types, including StructA and UnionA is not implemented at this time,
+and will always appear as empty.
 
 .. doxygenclass:: pvxs::Value
     :members:

--- a/example/client.cpp
+++ b/example/client.cpp
@@ -34,7 +34,7 @@ int main(int argc, char* argv[])
     logger_config_env();
 
     // Create a client context
-    client::Context ctxt(client::Config::from_env()
+    client::Context ctxt(client::Config::fromEnv()
                          .build());
 
     // Fetch current value

--- a/example/mailbox.cpp
+++ b/example/mailbox.cpp
@@ -85,7 +85,7 @@ int main(int argc, char* argv[])
 
     // Build server which will server this PV
     // Configure using process environment.
-    server::Server serv = server::Config::from_env()
+    server::Server serv = server::Config::fromEnv()
             .build()
             .addPV(argv[1], pv);
 

--- a/example/mailbox.cpp
+++ b/example/mailbox.cpp
@@ -74,7 +74,7 @@ int main(int argc, char* argv[])
 
         // (optional) update the SharedPV cache and send
         // a update to any subscribers
-        pv.post(std::move(top));
+        pv.post(top);
 
         // Required.  Inform client that PUT operation is complete.
         op->reply();

--- a/example/spam.cpp
+++ b/example/spam.cpp
@@ -62,7 +62,7 @@ public:
 
                     log_debug_printf(app, "%s count %u\n", sub->peerName().c_str(), unsigned(cnt));
 
-                }while(sub->tryPost(std::move(update)));
+                }while(sub->tryPost(update));
             };
 
             sub->onHighMark(fill);

--- a/example/spam.cpp
+++ b/example/spam.cpp
@@ -102,7 +102,7 @@ int main(int argc, char* argv[])
 
     // Build server which will server this PV
     // Configure using process environment.
-    server::Server serv = server::Config::from_env()
+    server::Server serv = server::Config::fromEnv()
             .build()
             .addSource("spamsrc", src);
 

--- a/example/ticker.cpp
+++ b/example/ticker.cpp
@@ -72,7 +72,7 @@ int main(int argc, char* argv[])
 
     // Build server which will server this PV
     // Configure using process environment.
-    server::Server serv = server::Config::from_env()
+    server::Server serv = server::Config::fromEnv()
             .build()
             .addPV(argv[1], pv);
 

--- a/example/ticker.cpp
+++ b/example/ticker.cpp
@@ -100,7 +100,7 @@ int main(int argc, char* argv[])
 
         val["value"] = count++;
 
-        pv.post(std::move(val));
+        pv.post(val);
 
         std::cout<<"Count "<<count<<"\n";
     }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -412,10 +412,11 @@ void Context::Pvt::close()
         conns.clear();
         chans.clear();
 
-        assert(internal_self.use_count()==1);
+        // internal_self.use_count() may be >1 if
+        // we are orphaning some Operations
     });
 
-    tcp_loop.join();
+    tcp_loop.sync();
 
     // ensure any in-progress callbacks have completed
     manager.sync();

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -165,6 +165,11 @@ OperationBase::OperationBase(operation_t op, const std::shared_ptr<Channel>& cha
 
 OperationBase::~OperationBase() {}
 
+const std::string& OperationBase::name()
+{
+    return chan->name;
+}
+
 Value OperationBase::wait(double timeout)
 {
     if(!waiter)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -361,6 +361,7 @@ Context::Pvt::Pvt(const Config& conf)
         auto top = ntohl(saddr->in.sin_addr.s_addr)>>24u;
         auto isucast = !isbcast && top<239 && top>224;
 
+        log_info_printf(io, "Searching to %s%s\n", saddr.tostring().c_str(), (isucast?" unicast":""));
         searchDest.emplace_back(saddr, isucast);
     }
 

--- a/src/clientget.cpp
+++ b/src/clientget.cpp
@@ -475,6 +475,9 @@ void gpr_cleanup(std::shared_ptr<Operation>& ret, std::shared_ptr<GPROp>&& op)
 
 std::shared_ptr<Operation> GetBuilder::_exec_get()
 {
+    if(!ctx)
+        throw std::logic_error("NULL Builder");
+
     std::shared_ptr<Operation> ret;
     assert(_get);
 
@@ -497,6 +500,9 @@ std::shared_ptr<Operation> GetBuilder::_exec_get()
 
 std::shared_ptr<Operation> PutBuilder::exec()
 {
+    if(!ctx)
+        throw std::logic_error("NULL Builder");
+
     std::shared_ptr<Operation> ret;
 
     if(!_builder && !_args)
@@ -535,6 +541,9 @@ std::shared_ptr<Operation> PutBuilder::exec()
 
 std::shared_ptr<Operation> RPCBuilder::exec()
 {
+    if(!ctx)
+        throw std::logic_error("NULL Builder");
+
     std::shared_ptr<Operation> ret;
 
     if(_args && _argument)

--- a/src/clientget.cpp
+++ b/src/clientget.cpp
@@ -326,7 +326,7 @@ void Connection::handle_GPR(pva_app_msg_t cmd)
         op = info->handle.lock();
         if(!op) {
             // assume op has already sent CMD_DESTROY_REQUEST
-            log_debug_printf(io, "Server %s ignoring stake cmd%02x ioid %u\n",
+            log_debug_printf(io, "Server %s ignoring stale cmd%02x ioid %u\n",
                              peerName.c_str(), cmd, unsigned(ioid));
             return;
         }

--- a/src/clientget.cpp
+++ b/src/clientget.cpp
@@ -456,9 +456,11 @@ static
 void gpr_cleanup(std::shared_ptr<Operation>& ret, std::shared_ptr<GPROp>&& op)
 {
     auto cap(std::move(op));
-    ret.reset(cap.get(), [cap](Operation*) mutable {
+    auto loop(cap->chan->context->tcp_loop);
+    ret.reset(cap.get(), [cap, loop](Operation*) mutable {
+        auto L(std::move(loop));
         // from use thread
-        cap->chan->context->tcp_loop.call([&cap]() {
+        L.call([&cap]() {
             auto temp(std::move(cap));
             // on worker
             try {

--- a/src/clientimpl.h
+++ b/src/clientimpl.h
@@ -43,9 +43,9 @@ struct ResultWaiter {
 struct OperationBase : public Operation
 {
     const std::shared_ptr<Channel> chan;
-    uint32_t ioid;
+    uint32_t ioid = 0;
     Value result;
-    bool done;
+    bool done = false;
     std::shared_ptr<ResultWaiter> waiter;
 
     OperationBase(operation_t op, const std::shared_ptr<Channel>& chan);

--- a/src/clientimpl.h
+++ b/src/clientimpl.h
@@ -186,6 +186,7 @@ struct Context::Pvt
     uint16_t searchRxPort;
 
     epicsTimeStamp lastPoke{};
+    bool poked = false;
 
     std::vector<uint8_t> searchMsg;
 
@@ -228,7 +229,7 @@ struct Context::Pvt
 
     void close();
 
-    void poke();
+    void poke(bool force);
 
     void onBeacon(const UDPManager::Beacon& msg);
 

--- a/src/clientimpl.h
+++ b/src/clientimpl.h
@@ -54,6 +54,7 @@ struct OperationBase : public Operation
     virtual void createOp() =0;
     virtual void disconnected(const std::shared_ptr<OperationBase>& self) =0;
 
+    virtual const std::string& name() override final;
     virtual Value wait(double timeout=-1.0) override final;
     virtual void interrupt() override final;
 };

--- a/src/clientintrospect.cpp
+++ b/src/clientintrospect.cpp
@@ -168,6 +168,9 @@ void Connection::handle_GET_FIELD()
 
 std::shared_ptr<Operation> GetBuilder::_exec_info()
 {
+    if(!ctx)
+        throw std::logic_error("NULL Builder");
+
     std::shared_ptr<Operation> ret;
 
     assert(!_get);

--- a/src/clientmon.cpp
+++ b/src/clientmon.cpp
@@ -504,6 +504,9 @@ void Connection::handle_MONITOR()
 
 std::shared_ptr<Subscription> MonitorBuilder::exec()
 {
+    if(!ctx)
+        throw std::logic_error("NULL Builder");
+
     std::shared_ptr<Subscription> ret;
 
     ctx->tcp_loop.call([&ret, this]() {

--- a/src/clientmon.cpp
+++ b/src/clientmon.cpp
@@ -386,7 +386,7 @@ void Connection::handle_MONITOR()
         op = info->handle.lock();
         if(!op) {
             // assume op has already sent CMD_DESTROY_REQUEST
-            log_debug_printf(io, "Server %s ignoring stake cmd%02x ioid %u\n",
+            log_debug_printf(io, "Server %s ignoring stale cmd%02x ioid %u\n",
                              peerName.c_str(), CMD_MONITOR, unsigned(ioid));
             return;
         }

--- a/src/clientreq.cpp
+++ b/src/clientreq.cpp
@@ -31,11 +31,11 @@ struct CommonBase::Req {
 
 CommonBase::~CommonBase() {}
 
-void CommonBase::_rawRequest(Value&& raw)
+void CommonBase::_rawRequest(const Value& raw)
 {
     if(!req)
         req = std::make_shared<Req>();
-    req->pvRequest = std::move(raw);
+    req->pvRequest = raw;
 }
 void CommonBase::_field(const std::string& s)
 {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -59,6 +59,18 @@ std::string join_addr(const std::vector<std::string>& in)
     return strm.str();
 }
 
+void parse_bool(bool& dest, const std::string& name, const std::string& val)
+{
+    if(epicsStrCaseCmp(val.c_str(), "YES")==0 || val=="1") {
+        dest = true;
+    } else if(epicsStrCaseCmp(val.c_str(), "NO")==0 || val=="0") {
+        dest = false;
+    } else {
+        log_err_printf(serversetup, "%s invalid bool value (YES/NO) : '%s'\n",
+                       name.c_str(), val.c_str());
+    }
+}
+
 struct PickOne {
     const std::map<std::string, std::string>& defs;
     bool useenv;
@@ -183,13 +195,7 @@ void _fromDefs(Config& self, const std::map<std::string, std::string>& defs, boo
     }
 
     if(pickone({"EPICS_PVAS_AUTO_BEACON_ADDR_LIST", "EPICS_PVA_AUTO_ADDR_LIST"})) {
-        if(epicsStrCaseCmp(pickone.val.c_str(), "YES")==0) {
-            self.auto_beacon = true;
-        } else if(epicsStrCaseCmp(pickone.val.c_str(), "NO")==0) {
-            self.auto_beacon = false;
-        } else {
-            log_err_printf(serversetup, "%s invalid bool value (YES/NO)", pickone.name.c_str());
-        }
+        parse_bool(self.auto_beacon, pickone.name, pickone.val);
     }
 }
 
@@ -305,13 +311,7 @@ void _fromDefs(Config& self, const std::map<std::string, std::string>& defs, boo
     }
 
     if(pickone({"EPICS_PVA_AUTO_ADDR_LIST"})) {
-        if(epicsStrCaseCmp(pickone.val.c_str(), "YES")==0) {
-            self.autoAddrList = true;
-        } else if(epicsStrCaseCmp(pickone.val.c_str(), "NO")==0) {
-            self.autoAddrList = false;
-        } else {
-            log_err_printf(serversetup, "%s invalid bool value (YES/NO)", pickone.name.c_str());
-        }
+        parse_bool(self.autoAddrList, pickone.name, pickone.val);
     }
 }
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -25,7 +25,8 @@ DEFINE_LOGGER(config, "pvxs.config");
 namespace pvxs {
 
 namespace {
-void split_addr_into(const char* name, std::vector<std::string>& out, const std::string& inp, uint16_t defaultPort)
+void split_addr_into(const char* name, std::vector<std::string>& out, const std::string& inp,
+                     uint16_t defaultPort, bool required=false)
 {
     size_t pos=0u;
 
@@ -39,6 +40,8 @@ void split_addr_into(const char* name, std::vector<std::string>& out, const std:
 
             sockaddr_in addr = {};
             if(aToIPAddr(temp.c_str(), defaultPort, &addr)) {
+                if(required)
+                    throw std::runtime_error(SB()<<"invalid IP or non-existent hostname \""<<temp<<"\"");
                 log_err_printf(config, "%s ignoring invalid '%s'\n", name, temp.c_str());
                 continue;
             }
@@ -172,7 +175,7 @@ void _fromDefs(Config& self, const std::map<std::string, std::string>& defs, boo
     }
 
     if(pickone({"EPICS_PVAS_INTF_ADDR_LIST"})) {
-        split_addr_into(pickone.name.c_str(), self.interfaces, pickone.val, self.tcp_port);
+        split_addr_into(pickone.name.c_str(), self.interfaces, pickone.val, self.tcp_port, true);
     }
 
     if(pickone({"EPICS_PVAS_BEACON_ADDR_LIST", "EPICS_PVA_ADDR_LIST"})) {

--- a/src/conn.cpp
+++ b/src/conn.cpp
@@ -169,32 +169,37 @@ void ConnBase::bevRead()
             expectSeg = false;
 
             // ready to process segBuf
-            switch(segCmd) {
-            default:
-                log_debug_printf(connio, "%s %s Ignore unexpected command 0x%02x\n", peerLabel(), peerName.c_str(), segCmd);
-                evbuffer_drain(segBuf.get(), evbuffer_get_length(segBuf.get()));
-                break;
-#define CASE(OP) case CMD_##OP: handle_##OP(); break
-                CASE(ECHO);
-                CASE(CONNECTION_VALIDATION);
-                CASE(CONNECTION_VALIDATED);
-                CASE(SEARCH);
-                CASE(AUTHNZ);
+            try {
+                switch(segCmd) {
+                default:
+                    log_debug_printf(connio, "%s %s Ignore unexpected command 0x%02x\n", peerLabel(), peerName.c_str(), segCmd);
+                    evbuffer_drain(segBuf.get(), evbuffer_get_length(segBuf.get()));
+                    break;
+    #define CASE(OP) case CMD_##OP: handle_##OP(); break
+                    CASE(ECHO);
+                    CASE(CONNECTION_VALIDATION);
+                    CASE(CONNECTION_VALIDATED);
+                    CASE(SEARCH);
+                    CASE(AUTHNZ);
 
-                CASE(CREATE_CHANNEL);
-                CASE(DESTROY_CHANNEL);
+                    CASE(CREATE_CHANNEL);
+                    CASE(DESTROY_CHANNEL);
 
-                CASE(GET);
-                CASE(PUT);
-                CASE(PUT_GET);
-                CASE(MONITOR);
-                CASE(RPC);
-                CASE(CANCEL_REQUEST);
-                CASE(DESTROY_REQUEST);
-                CASE(GET_FIELD);
+                    CASE(GET);
+                    CASE(PUT);
+                    CASE(PUT_GET);
+                    CASE(MONITOR);
+                    CASE(RPC);
+                    CASE(CANCEL_REQUEST);
+                    CASE(DESTROY_REQUEST);
+                    CASE(GET_FIELD);
 
-                CASE(MESSAGE);
-#undef CASE
+                    CASE(MESSAGE);
+    #undef CASE
+                }
+            }catch(std::exception& e){
+                log_exc_printf(connio, "%s Error while processing cmd 0x%02x: %s\n", peerLabel(), segCmd, e.what());
+                bev.reset();
             }
             // handlers may have cleared bev to force disconnect
             if(!bev)

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -584,12 +584,18 @@ void Value::copyIn(const void *ptr, StoreType type)
         break;
     }
     case StoreType::Compound:
+        if(type==StoreType::Null) {
+            store->as<Value>() = Value(); // unselect Union or Any
+            break;
+        }
+
         if(desc->code==TypeCode::Any) {
             // assigning variant union.
             auto& val = store->as<Value>();
             if(type==StoreType::Compound) {
                 val = *reinterpret_cast<const Value*>(ptr);
                 break;
+
             } else {
                 val = Value::Helper::build(ptr, type);
                 break;

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -787,6 +787,19 @@ const Value Value::operator[](const char *name) const
     return ret;
 }
 
+size_t Value::nmembers() const
+{
+    switch(desc ? desc->code.code : TypeCode::Null) {
+    case TypeCode::Struct:
+    case TypeCode::StructA:
+    case TypeCode::Union:
+    case TypeCode::UnionA:
+        return desc->miter.size();
+    default:
+        return 0u;
+    }
+}
+
 void Value::_iter_fl(Value::IterInfo &info, bool first) const
 {
     if(!store)

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -512,9 +512,41 @@ void Value::copyIn(const void *ptr, StoreType type)
         throw NoField();
 
     switch(store->code) {
-    case StoreType::Real:     if(!copyInScalar(store->as<double>(), ptr, type)) throw NoConvert(); break;
-    case StoreType::Integer:  if(!copyInScalar(store->as<int64_t>(), ptr, type)) throw NoConvert(); break;
-    case StoreType::UInteger: if(!copyInScalar(store->as<uint64_t>(), ptr, type)) throw NoConvert(); break;
+    case StoreType::Real: {
+        if(!copyInScalar(store->as<double>(), ptr, type)) throw NoConvert();
+        // truncate as if assigned to narrower type
+        if(desc->code==TypeCode::Float32)
+            store->as<double>() = float(store->as<double>());
+        break;
+    }
+    case StoreType::Integer: {
+        if(!copyInScalar(store->as<int64_t>(), ptr, type)) throw NoConvert();
+        // truncate as if assigned to narrower type
+        int64_t orig = store->as<int64_t>();
+        switch(desc->code.code) {
+        case TypeCode::Int8: orig = int8_t(orig); break;
+        case TypeCode::Int16: orig = int16_t(orig); break;
+        case TypeCode::Int32: orig = int32_t(orig); break;
+        case TypeCode::Int64: orig = int64_t(orig); break;
+        default: break;
+        }
+        store->as<int64_t>() = orig;
+        break;
+    }
+    case StoreType::UInteger: {
+        if(!copyInScalar(store->as<uint64_t>(), ptr, type)) throw NoConvert();
+        // truncate as if assigned to narrower type
+        int64_t orig = store->as<int64_t>();
+        switch(desc->code.code) {
+        case TypeCode::UInt8: orig = uint8_t(orig); break;
+        case TypeCode::UInt16: orig = uint16_t(orig); break;
+        case TypeCode::UInt32: orig = uint32_t(orig); break;
+        case TypeCode::UInt64: orig = uint64_t(orig); break;
+        default: break;
+        }
+        store->as<int64_t>() = orig;
+        break;
+    }
     case StoreType::Bool: {
         auto& dest = store->as<bool>();
         switch(type) {

--- a/src/datafmt.cpp
+++ b/src/datafmt.cpp
@@ -127,10 +127,9 @@ struct FmtTree {
 
     void top(const std::string& member,
              const FieldDesc *desc,
-             const FieldStorage* store,
-             unsigned level=0)
+             const FieldStorage* store)
     {
-        indent(strm, level);
+        strm<<indent{};
         if(!desc) {
             strm<<"null\n";
             return;
@@ -148,10 +147,10 @@ struct FmtTree {
                 strm<<" {\n";
                 for(auto& pair : desc->miter) {
                     auto cdesc = desc + pair.second;
-                    top(pair.first, cdesc, store + pair.second, level+1);
+                    Indented I(strm);
+                    top(pair.first, cdesc, store + pair.second);
                 }
-                indent(strm, level);
-                strm<<"}";
+                strm<<indent{}<<"}";
                 if(!member.empty())
                     strm<<" "<<member;
                 strm<<"\n";
@@ -174,10 +173,10 @@ struct FmtTree {
                     }
                 }
             }
+            Indented I(strm);
             top(std::string(),
                 Value::Helper::desc(fld),
-                Value::Helper::store_ptr(fld),
-                level+1);
+                Value::Helper::store_ptr(fld));
         }
             break;
         case StoreType::Array: {
@@ -190,13 +189,12 @@ struct FmtTree {
                 auto arr = varr.castTo<const Value>();
                 strm<<" [\n";
                 for(auto& val : arr) {
+                    Indented I(strm);
                     top(std::string(),
                         Value::Helper::desc(val),
-                        Value::Helper::store_ptr(val),
-                        level+1);
+                        Value::Helper::store_ptr(val));
                 }
-                indent(strm, level);
-                strm<<"]\n";
+                strm<<indent{}<<"]\n";
             }
         }
             break;

--- a/src/dataimpl.h
+++ b/src/dataimpl.h
@@ -48,11 +48,8 @@ struct Buffer;
  * with offset to descendant fields given as positive integers relative
  * to the current field.  (not possible to jump _back_)
  *
- * We deal with two different numeric values:
- * 1. indicies in this FieldDesc array.  found in FieldDesc::mlookup and FieldDesc::miter
- *    Relative to current position in FieldDesc array.  (aka this+n)
- * 2. offsets in associated FieldStorage array.  found in FieldDesc::index
- *    Relative to current FieldDesc*.
+ * We deal with indicies in this FieldDesc array.  found in FieldDesc::mlookup
+ * and FieldDesc::miter Relative to current position in FieldDesc array.  (aka this+n)
  */
 struct FieldDesc {
     // type ID string (Struct/Union)
@@ -60,8 +57,8 @@ struct FieldDesc {
 
     // Lookup of all descendant fields of this Structure or Union.
     // "fld.sub.leaf" -> rel index
-    // For Struct, relative to this
-    // For Union, offset in members array
+    // For Struct, relative to this (always >=1)
+    // For Union, offset in members array (one entry will always be zero)
     std::map<std::string, size_t> mlookup;
 
     // child iteration.  child# -> ("sub", rel index in enclosing vector<FieldDesc>)
@@ -73,8 +70,8 @@ struct FieldDesc {
     size_t parent_index=0;
 
     // For Union, UnionA, StructA
-    // For Union, the choices
-    // For UnionA/StructA, size()==1 containing a Union/Struct
+    // For Union, the choices concatenated together (members.size() !+ #choices)
+    // For UnionA/StructA containing a single Union/Struct
     std::vector<FieldDesc> members;
 
     TypeCode code{TypeCode::Null};

--- a/src/evhelper.cpp
+++ b/src/evhelper.cpp
@@ -107,8 +107,8 @@ struct evbase::Pvt : public epicsThreadRunable
         std::function<void()> fn;
         std::exception_ptr *result;
         epicsEvent *notify;
-        Work(const std::function<void()>& fn, std::exception_ptr *result, epicsEvent *notify)
-            :fn(fn), result(result), notify(notify)
+        Work(std::function<void()>&& fn, std::exception_ptr *result, epicsEvent *notify)
+            :fn(std::move(fn)), result(result), notify(notify)
         {}
     };
     std::deque<Work> actions;

--- a/src/evhelper.cpp
+++ b/src/evhelper.cpp
@@ -122,6 +122,8 @@ struct evbase::Pvt : public epicsThreadRunable
     epicsThread worker;
     bool running = true;
 
+    INST_COUNTER(evbase);
+
     Pvt(const std::string& name, unsigned prio)
         :worker(*this, name.c_str(),
                 epicsThreadGetStackSize(epicsThreadStackBig),

--- a/src/evhelper.h
+++ b/src/evhelper.h
@@ -60,6 +60,9 @@ struct owned_ptr : public std::unique_ptr<T>
 };
 
 struct PVXS_API evbase {
+    evbase() = default;
+    evbase(const evbase&) = default;
+    evbase(evbase&&) = default;
     explicit evbase(const std::string& name, unsigned prio=0);
     ~evbase();
     void join();
@@ -75,12 +78,13 @@ struct PVXS_API evbase {
     void assertInLoop();
     bool inLoop();
 
-    INST_COUNTER(evbase);
+    inline void reset() { pvt.reset(); }
+
 private:
     struct Pvt;
-    std::unique_ptr<Pvt> pvt;
+    std::shared_ptr<Pvt> pvt;
 public:
-    event_base* const base;
+    event_base* base = nullptr;
 };
 
 typedef owned_ptr<event> evevent;

--- a/src/pvrequest.cpp
+++ b/src/pvrequest.cpp
@@ -71,5 +71,25 @@ BitMask request2mask(const FieldDesc* desc, const Value& pvRequest)
     return ret;
 }
 
+bool testmask(const Value& update, const BitMask& mask)
+{
+    auto desc = Value::Helper::desc(update);
+    auto store = Value::Helper::store_ptr(update);
+
+    if(!desc)
+        return false;
+
+    if(store->valid && mask[0])
+        return true;
+
+    if(desc->code==TypeCode::Struct) {
+        for(auto idx : range(size_t(1u), desc->size())) {
+            if(store[idx].valid && mask[idx])
+                return true;
+        }
+    }
+
+    return false;
+}
 
 }} // namespace pvxs::impl

--- a/src/pvrequest.h
+++ b/src/pvrequest.h
@@ -16,6 +16,9 @@ namespace impl {
 PVXS_API
 BitMask request2mask(const FieldDesc* desc, const Value& pvRequest);
 
+PVXS_API
+bool testmask(const Value& update, const BitMask& mask);
+
 }} // namespace pvxs::impl
 
 #endif // PVREQUEST_H

--- a/src/pvxs/client.h
+++ b/src/pvxs/client.h
@@ -335,7 +335,7 @@ public:
      * @endcode
      */
     inline
-    RPCBuilder rpc(const std::string& pvname, Value&& arg);
+    RPCBuilder rpc(const std::string& pvname, const Value& arg);
 
     /** Create a new subscription for changes to a PV.
      *
@@ -629,9 +629,9 @@ public:
     friend struct Context::Pvt;
 };
 RPCBuilder Context::rpc(const std::string& name) { return RPCBuilder{pvt, name}; }
-RPCBuilder Context::rpc(const std::string& name, Value&& arg) {
+RPCBuilder Context::rpc(const std::string& name, const Value &arg) {
     RPCBuilder ret{pvt, name};
-    ret._argument = std::move(arg);
+    ret._argument = arg;
     return ret;
 }
 

--- a/src/pvxs/client.h
+++ b/src/pvxs/client.h
@@ -98,6 +98,7 @@ public:
 
 //! Handle for in-progress operation
 struct PVXS_API Operation {
+    //! Operation type
     const enum operation_t {
         Info    = 17, // CMD_GET_FIELD
         Get     = 10, // CMD_GET
@@ -110,6 +111,9 @@ struct PVXS_API Operation {
     Operation(const Operation&) = delete;
     Operation& operator=(const Operation&) = delete;
     virtual ~Operation() =0;
+
+    //! PV name
+    virtual const std::string& name() =0;
 
     //! Explicitly cancel a pending operation.
     //! Blocks until an in-progress callback has completed.

--- a/src/pvxs/client.h
+++ b/src/pvxs/client.h
@@ -399,6 +399,7 @@ protected:
     std::shared_ptr<Req> req;
     unsigned _prio = 0u;
 
+    CommonBase() = default;
     CommonBase(const std::shared_ptr<Context::Pvt>& ctx, const std::string& name) : ctx(ctx), _name(name) {}
     ~CommonBase();
 
@@ -416,6 +417,7 @@ protected:
     struct Args;
     std::shared_ptr<Args> _args;
 
+    PRBase() = default;
     PRBase(const std::shared_ptr<Context::Pvt>& ctx, const std::string& name) : CommonBase(ctx, name) {}
     ~PRBase();
 
@@ -428,6 +430,7 @@ protected:
 template<typename SubBuilder, typename Base>
 class CommonBuilder : public Base {
 protected:
+    CommonBuilder() = default;
     constexpr CommonBuilder(const std::shared_ptr<Context::Pvt>& ctx, const std::string& name) : Base(ctx, name) {}
     inline SubBuilder& _sb() { return static_cast<SubBuilder&>(*this); }
 public:
@@ -475,12 +478,13 @@ public:
 //! Prepare a remote GET or GET_FIELD (info) operation.
 class GetBuilder : public detail::CommonBuilder<GetBuilder, detail::CommonBase> {
     std::function<void(Result&&)> _result;
-    bool _get;
+    bool _get = false;
     PVXS_API
     std::shared_ptr<Operation> _exec_info();
     PVXS_API
     std::shared_ptr<Operation> _exec_get();
 public:
+    GetBuilder() = default;
     GetBuilder(const std::shared_ptr<Context::Pvt>& ctx, const std::string& name, bool get) :CommonBuilder{ctx,name}, _get(get) {}
     //! Callback through which result Value or an error will be delivered.
     //! The functor is stored in the Operation returned by exec().
@@ -505,6 +509,7 @@ class PutBuilder : public detail::CommonBuilder<PutBuilder, detail::PRBase> {
     std::function<Value(Value&&)> _builder;
     std::function<void(Result&&)> _result;
 public:
+    PutBuilder() = default;
     PutBuilder(const std::shared_ptr<Context::Pvt>& ctx, const std::string& name) :CommonBuilder{ctx,name} {}
 
     /** If fetchPresent is true (the default).  Then the Value passed to
@@ -569,6 +574,7 @@ class RPCBuilder : public detail::CommonBuilder<RPCBuilder, detail::PRBase> {
     std::function<void(Result&&)> _result;
     friend class Context;
 public:
+    RPCBuilder() = default;
     RPCBuilder(const std::shared_ptr<Context::Pvt>& ctx, const std::string& name) :CommonBuilder{ctx,name} {}
     //! Callback through which result Value or an error will be delivered.
     //! The functor is stored in the Operation returned by exec().
@@ -614,6 +620,7 @@ class MonitorBuilder : public detail::CommonBuilder<MonitorBuilder, detail::Comm
     bool _maskConn = true;
     bool _maskDisconn = false;
 public:
+    MonitorBuilder() = default;
     MonitorBuilder(const std::shared_ptr<Context::Pvt>& ctx, const std::string& name) :CommonBuilder{ctx,name} {}
     //! Install event callback
     //! The functor is stored in the Subscription returned by exec().
@@ -633,7 +640,6 @@ MonitorBuilder Context::monitor(const std::string& name) { return MonitorBuilder
 class RequestBuilder : public detail::CommonBuilder<RequestBuilder, detail::CommonBase>
 {
 public:
-    RequestBuilder() :CommonBuilder{nullptr,std::string()} {}
     //! Return composed pvRequest
     Value build() const {
         return _buildReq();

--- a/src/pvxs/client.h
+++ b/src/pvxs/client.h
@@ -184,6 +184,7 @@ class GetBuilder;
 class PutBuilder;
 class RPCBuilder;
 class MonitorBuilder;
+class RequestBuilder;
 
 /** An independent PVA protocol client instance
  *
@@ -351,6 +352,23 @@ public:
      */
     inline
     MonitorBuilder monitor(const std::string& pvname);
+
+    /** Compose a pvRequest independently of a network operation.
+     *
+     * This is not a network operation.
+     *
+     * Use of request() is optional.  pvRequests can be composed
+     * with individual network operation Builders.
+     *
+     * @code
+     * Value pvReq = Context::request()
+     *                      .pvRequest("field(value)field(blah)")
+     *                      .record("pipeline", true)
+     *                      .build();
+     * @endcode
+     */
+    static inline
+    RequestBuilder request();
 
     /** Request prompt search of any disconnected channels.
      *
@@ -611,6 +629,17 @@ public:
     friend struct Context::Pvt;
 };
 MonitorBuilder Context::monitor(const std::string& name) { return MonitorBuilder{pvt, name}; }
+
+class RequestBuilder : public detail::CommonBuilder<RequestBuilder, detail::CommonBase>
+{
+public:
+    RequestBuilder() :CommonBuilder{nullptr,std::string()} {}
+    //! Return composed pvRequest
+    Value build() const {
+        return _buildReq();
+    }
+};
+RequestBuilder Context::request() { return RequestBuilder{}; }
 
 struct PVXS_API Config {
     //! List of unicast and broadcast addresses

--- a/src/pvxs/client.h
+++ b/src/pvxs/client.h
@@ -117,7 +117,8 @@ struct PVXS_API Operation {
 
     //! Explicitly cancel a pending operation.
     //! Blocks until an in-progress callback has completed.
-    virtual void cancel() =0;
+    //! @returns true if the operation was cancelled, or false if already complete.
+    virtual bool cancel() =0;
 
     /** @brief Block until Operation completion
      *
@@ -147,7 +148,7 @@ struct PVXS_API Subscription {
 
     //! Explicitly cancel a active subscription.
     //! Blocks until any in-progress callback has completed.
-    virtual void cancel() =0;
+    virtual bool cancel() =0;
 
     //! Ask a server to stop sending updates to this Subscription
     virtual void pause(bool p=true) =0;

--- a/src/pvxs/client.h
+++ b/src/pvxs/client.h
@@ -403,7 +403,7 @@ protected:
     CommonBase(const std::shared_ptr<Context::Pvt>& ctx, const std::string& name) : ctx(ctx), _name(name) {}
     ~CommonBase();
 
-    void _rawRequest(Value&&);
+    void _rawRequest(const Value&);
     void _field(const std::string& s);
     void _record(const std::string& key, const void* value, StoreType vtype);
     void _parse(const std::string& req);
@@ -467,7 +467,7 @@ public:
     SubBuilder& pvRequest(const std::string& expr) { this->_parse(expr); return _sb(); }
 
     //! Store raw pvRequest blob.
-    SubBuilder& rawRequest(Value&& r) { this->_rawRequest(std::move(r)); return _sb(); }
+    SubBuilder& rawRequest(const Value& r) { this->_rawRequest(r); return _sb(); }
 
     SubBuilder& priority(int p) { this->_prio = p; return _sb(); }
     SubBuilder& server(const std::string& s) { this->_server = s; return _sb(); }

--- a/src/pvxs/client.h
+++ b/src/pvxs/client.h
@@ -376,6 +376,23 @@ public:
 
     /** Request prompt search of any disconnected channels.
      *
+     * This method is recommended for use when executing a batch of operations.
+     *
+     * @code
+     * Context ctxt = ...;
+     * std::vector<std::string> pvnames = ...;
+     * std::vector<Operation> ops(pvnames.size());
+     *
+     * // Initiate all operations
+     * for(size_t i=0; i<pvname.size(); i++)
+     *     ops[i] = ctxt.get(pvnames[i]).exec();
+     *
+     * ctxt.hurryUp(); // indicate end of batch
+     *
+     * for(size_t i=0; i<pvname.size(); i++)
+     *     ... = ops[i].wait(); // wait for results
+     * @endcode
+     *
      * Optional.  Equivalent to detection of a new server.
      * This method has no effect if called more often than once per 30 seconds.
      */

--- a/src/pvxs/client.h
+++ b/src/pvxs/client.h
@@ -8,6 +8,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <map>
 #include <vector>
 #include <memory>
 #include <functional>
@@ -625,8 +626,23 @@ struct PVXS_API Config {
     //! Whether to extend the addressList with local interface broadcast addresses.  (recommended)
     bool autoAddrList = true;
 
+    // compat
+    static inline Config from_env() { return Config{}.applyEnv(); }
+
     //! Default configuration using process environment
-    static Config from_env();
+    static inline Config fromEnv()  { return Config{}.applyEnv(); }
+
+    //! update using defined EPICS_PVA* environment variables
+    Config& applyEnv();
+
+    typedef std::map<std::string, std::string> defs_t;
+    //! update with definitions as with EPICS_PVA* environment variables
+    //! Process environment is not changed.
+    Config& applyDefs(const defs_t& defs);
+
+    //! extract definitions with environment variable names as keys.
+    //! Process environment is not changed.
+    void updateDefs(defs_t& defs) const;
 
     /** Apply rules to translate current requested configuration
      *  into one which can actually be loaded based on current host network configuration.

--- a/src/pvxs/data.h
+++ b/src/pvxs/data.h
@@ -667,6 +667,10 @@ public:
     const Value operator[](const char *name) const;
     inline const Value operator[](const std::string& name) const { return (*this)[name.c_str()]; }
 
+    //! Number of child fields.
+    //! only Struct, StructA, Union, UnionA return non-zero
+    size_t nmembers() const;
+
     template<typename V>
     class Iterable;
 private:

--- a/src/pvxs/data.h
+++ b/src/pvxs/data.h
@@ -741,7 +741,7 @@ public:
 
 template<typename V>
 class Value::Iter : private Value::IterInfo {
-    const Value ref;
+    Value ref;
     constexpr Iter(const Value& ref, size_t pos, bool marked, bool depth)
         :IterInfo(pos, marked, depth), ref(ref)
     {}
@@ -770,11 +770,12 @@ public:
 
 template<typename V>
 class Value::Iterable {
-    typedef Iter<V> iterator;
-    const Value owner;
-    bool marked;
-    bool depth;
+    Value owner;
+    bool marked = false;
+    bool depth = false;
 public:
+    typedef Iter<V> iterator;
+    constexpr Iterable() = default;
     constexpr Iterable(const Value& owner, bool marked, bool depth) :owner(owner), marked(marked), depth(depth) {}
     iterator begin() const {
         iterator ret{owner, 0u, marked, depth};

--- a/src/pvxs/data.h
+++ b/src/pvxs/data.h
@@ -211,10 +211,8 @@ inline bool operator==(TypeCode lhs, TypeCode rhs) {
 inline bool operator!=(TypeCode lhs, TypeCode rhs) {
     return lhs.code!=rhs.code;
 }
-inline std::ostream& operator<<(std::ostream& strm, TypeCode c) {
-    strm<<c.name();
-    return strm;
-}
+PVXS_API
+std::ostream& operator<<(std::ostream& strm, TypeCode c);
 
 namespace impl {
 template<typename T>

--- a/src/pvxs/data.h
+++ b/src/pvxs/data.h
@@ -37,6 +37,9 @@ enum struct StoreType : uint8_t {
     Array,    //!< shared_array<const void>
 };
 
+PVXS_API
+std::ostream& operator<<(std::ostream& strm, StoreType c);
+
 constexpr struct unselect_t {} unselect;
 
 namespace impl {
@@ -450,7 +453,7 @@ struct PVXS_API NoField : public std::runtime_error
 //! Thrown when a Value can not be converted to the requested type
 struct PVXS_API NoConvert : public std::runtime_error
 {
-    explicit NoConvert();
+    NoConvert(const std::string& msg) : std::runtime_error(msg) {}
     virtual ~NoConvert();
 };
 
@@ -521,7 +524,7 @@ public:
     //! Use to allocate members for an array of Struct and array of Union
     Value allocMember();
 
-    //! Does this Value actual reference some underlying storage
+    //! Does this Value actually reference some underlying storage
     inline bool valid() const { return desc; }
     inline explicit operator bool() const { return desc; }
 
@@ -581,6 +584,9 @@ public:
      * - std::string
      * - Value
      * - shared_array<const void>
+     *
+     * @throws NoField !this->valid()
+     * @throws NoConvert if the field value can not be coerced to type T
      */
     template<typename T>
     inline T as() const {

--- a/src/pvxs/data.h
+++ b/src/pvxs/data.h
@@ -679,7 +679,10 @@ private:
         // all [pos, nextcheck) are marked
         size_t pos;
         size_t nextcheck;
+        // true only iterates marked fields (Struct),
+        // or only the selected field (Union)
         bool marked;
+        // false only iterates children (Struct only)
         bool depth;
         constexpr IterInfo() :pos(0u), nextcheck(0u), marked(false), depth(false) {}
         constexpr IterInfo(size_t pos, bool marked, bool depth)
@@ -757,15 +760,13 @@ public:
     V operator*() const { return ref._iter_deref(*this); }
     Iter& operator++() {
         pos++;
-        if(marked && pos >= nextcheck)
+        if(pos >= nextcheck)
             ref._iter_advance(*this);
         return *this;
     }
     Iter operator++(int) {
         Iter ret(*this);
-        pos++;
-        if(marked && pos >= nextcheck)
-            ref._iter_advance(*this);
+        ++(*this);
         return ret;
     }
     bool operator==(const Iter& o) const { return pos == o.pos; }

--- a/src/pvxs/data.h
+++ b/src/pvxs/data.h
@@ -37,6 +37,8 @@ enum struct StoreType : uint8_t {
     Array,    //!< shared_array<const void>
 };
 
+constexpr struct unselect_t {} unselect;
+
 namespace impl {
 struct FieldStorage;
 struct FieldDesc;
@@ -86,6 +88,10 @@ struct StorageMap<shared_array<const E>>
 template<>
 struct StorageMap<Value>
 { typedef Value store_t;   static constexpr StoreType code{StoreType::Compound}; };
+
+template<>
+struct StorageMap<unselect_t>
+{ typedef unselect_t store_t; static constexpr StoreType code{StoreType::Null}; };
 
 template<typename T>
 using StoreAs = StorageMap<typename std::decay<T>::type>;
@@ -229,7 +235,7 @@ CASE(std::string, std::string, String);
 
 #undef CASE
 
-} // namespace
+} // namespace impl
 
 //! Definition of a member of a Struct/Union for use with TypeDef
 struct Member {

--- a/src/pvxs/data.h
+++ b/src/pvxs/data.h
@@ -121,6 +121,8 @@ enum struct Kind : uint8_t {
     Null     = 0xe0,
 };
 
+enum class ArrayType : uint8_t;
+
 /** Possible Field types.
  *
  * eg. String is scalar string, StringA is array of strings.
@@ -183,6 +185,7 @@ struct TypeCode {
     constexpr TypeCode(code_t c) :code(c) {}
 
     PVXS_API StoreType storedAs() const;
+    PVXS_API ArrayType arrayType() const;
 
     //! associated array of type
     constexpr TypeCode arrayOf() const {return TypeCode{uint8_t(code|0x08)};}

--- a/src/pvxs/data.h
+++ b/src/pvxs/data.h
@@ -445,6 +445,12 @@ struct PVXS_API NoConvert : public std::runtime_error
     virtual ~NoConvert();
 };
 
+struct PVXS_API LookupError : public std::runtime_error
+{
+    explicit LookupError(const std::string& msg);
+    virtual ~LookupError();
+};
+
 /** Generic data container
  *
  * References a single data field, which may be free-standing (eg. "int x = 5;")
@@ -644,7 +650,7 @@ public:
 
     // Struct/Union access
 private:
-    void traverse(const std::string& expr, bool modify);
+    void traverse(const std::string& expr, bool modify, bool dothrow);
 public:
 
     /** Attempt to access a descendant field.
@@ -653,7 +659,7 @@ public:
      * * name of a child field.  eg. "value"
      * * name of a descendant field.  eg "alarm.severity"
      * * element of an array of structures.  eg "dimension[0]"
-     * * name of a union field.  eg. "booleanValue"
+     * * name of a union field.  eg. "->booleanValue"
      *
      * These may be composed.  eg.
      *
@@ -662,10 +668,18 @@ public:
      *
      * @returns A valid() Value if the descendant field exists, otherwise an invalid Value.
      */
-    Value operator[](const char *name);
-    inline Value operator[](const std::string& name) { return (*this)[name.c_str()]; }
-    const Value operator[](const char *name) const;
-    inline const Value operator[](const std::string& name) const { return (*this)[name.c_str()]; }
+    Value operator[](const std::string& name);
+    const Value operator[](const std::string& name) const;
+
+    /** Attempt to access a descendant field, or throw exception.
+     *
+     * Acts like operator[] on success, but throws a (hopefully descriptive)
+     * exception instead of returning an invalid Value.
+     *
+     * @throws LookupError If the lookup can not be satisfied
+     */
+    Value lookup(const std::string& name);
+    const Value lookup(const std::string& name) const;
 
     //! Number of child fields.
     //! only Struct, StructA, Union, UnionA return non-zero

--- a/src/pvxs/server.h
+++ b/src/pvxs/server.h
@@ -107,10 +107,17 @@ public:
 
     explicit operator bool() const { return !!pvt; }
 
+    friend
+    PVXS_API
+    std::ostream& operator<<(std::ostream& strm, const Server& serv);
+
     struct Pvt;
 private:
     std::shared_ptr<Pvt> pvt;
 };
+
+PVXS_API
+std::ostream& operator<<(std::ostream& strm, const Server& serv);
 
 //! Configuration for a Server
 struct PVXS_API Config {

--- a/src/pvxs/server.h
+++ b/src/pvxs/server.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <tuple>
 #include <set>
+#include <map>
 #include <vector>
 #include <memory>
 #include <array>
@@ -131,12 +132,27 @@ struct PVXS_API Config {
     //! Server unique ID.  Only meaningful in readback via Server::config()
     std::array<uint8_t, 12> guid{};
 
+    // compat
+    static inline Config from_env() { return Config{}.applyEnv(); }
+
     //! Default configuration using process environment
-    static Config from_env();
+    static inline Config fromEnv()  { return Config{}.applyEnv(); }
 
     //! Configuration limited to the local loopback interface on a randomly chosen port.
     //! Suitable for use in self-contained unit-tests.
     static Config isolated();
+
+    //! update using defined EPICS_PVA* environment variables
+    Config& applyEnv();
+
+    typedef std::map<std::string, std::string> defs_t;
+    //! update with definitions as with EPICS_PVA* environment variables.
+    //! Process environment is not changed.
+    Config& applyDefs(const defs_t& def);
+
+    //! extract definitions with environment variable names as keys.
+    //! Process environment is not changed.
+    void updateDefs(defs_t& defs) const;
 
     /** Apply rules to translate current requested configuration
      *  into one which can actually be loaded based on current host network configuration.

--- a/src/pvxs/sharedArray.h
+++ b/src/pvxs/sharedArray.h
@@ -47,6 +47,9 @@ std::ostream& operator<<(std::ostream& strm, ArrayType code);
 PVXS_API
 size_t elementSize(ArrayType type);
 
+//! Return a void array usable for the given storage type
+shared_array<void> allocArray(ArrayType type, size_t count);
+
 namespace detail {
 template<typename T>
 struct CaptureCode;

--- a/src/pvxs/sharedArray.h
+++ b/src/pvxs/sharedArray.h
@@ -48,6 +48,7 @@ PVXS_API
 size_t elementSize(ArrayType type);
 
 //! Return a void array usable for the given storage type
+PVXS_API
 shared_array<void> allocArray(ArrayType type, size_t count);
 
 namespace detail {

--- a/src/pvxs/sharedArray.h
+++ b/src/pvxs/sharedArray.h
@@ -474,15 +474,11 @@ public:
     template<typename TO, typename std::enable_if<!std::is_void<TO>::value && (std::is_const<E>::value == std::is_const<TO>::value), int>::type =0>
     shared_array<TO>
     convertTo() const {
-        if(detail::CaptureBase<TO>::code==detail::CaptureBase<E>::code) {
-            return castTo<TO>();
-        } else {
-            shared_array<TO> ret(this->_count);
-            detail::convertArr(detail::CaptureBase<TO>::code, (void*)ret._data.get(),
-                               detail::CaptureBase<E>::code, this->_data.get(),
-                               this->_count);
-            return ret;
-        }
+        shared_array<TO> ret(this->_count);
+        detail::convertArr(detail::CaptureBase<TO>::code, (void*)ret._data.get(),
+                           detail::CaptureBase<E>::code, this->_data.get(),
+                           this->_count);
+        return ret;
     }
 
     //! Provide options when rendering with std::ostream.

--- a/src/pvxs/sharedpv.h
+++ b/src/pvxs/sharedpv.h
@@ -99,6 +99,9 @@ struct PVXS_API StaticSource
     //! Fetch the Source interface, which may be used with Server::addSource()
     std::shared_ptr<Source> source() const;
 
+    //! call SharedPV::close() on all PVs
+    void close();
+
     //! Add a new name through which a SharedPV may be addressed.
     StaticSource& add(const std::string& name, const SharedPV& pv);
     //! Remove a single name

--- a/src/pvxs/sharedpv.h
+++ b/src/pvxs/sharedpv.h
@@ -52,9 +52,9 @@ struct PVXS_API SharedPV
     void attach(std::unique_ptr<ChannelControl>&& op);
 
     //! Callback when the number of attach()d clients becomes non-zero.
-    void onFirstConnect(std::function<void()>&& fn);
+    void onFirstConnect(std::function<void(SharedPV&)>&& fn);
     //! Callback when the number of attach()d clients becomes zero.
-    void onLastDisconnect(std::function<void()>&& fn);
+    void onLastDisconnect(std::function<void(SharedPV&)>&& fn);
     //! Callback when a client executes a new Put operation.
     void onPut(std::function<void(SharedPV&, std::unique_ptr<ExecOp>&&, Value&&)>&& fn);
     //! Callback when a client executes an RPC operation.

--- a/src/pvxs/sharedpv.h
+++ b/src/pvxs/sharedpv.h
@@ -71,7 +71,7 @@ struct PVXS_API SharedPV
     void close();
 
     //! Update the internal data value, and dispatch subscription updates to any clients.
-    void post(Value&& val);
+    void post(const Value& val);
     //! query the internal data value.
     void fetch(Value& val);
 

--- a/src/pvxs/sharedpv.h
+++ b/src/pvxs/sharedpv.h
@@ -72,8 +72,10 @@ struct PVXS_API SharedPV
 
     //! Update the internal data value, and dispatch subscription updates to any clients.
     void post(const Value& val);
-    //! query the internal data value.
-    void fetch(Value& val);
+    //! query the internal data value and update the provided Value.
+    void fetch(Value& val) const;
+    //! Return a (shallow) copy of the internal data value
+    Value fetch() const;
 
     struct Impl;
 private:

--- a/src/pvxs/sharedpv.h
+++ b/src/pvxs/sharedpv.h
@@ -9,6 +9,7 @@
 
 #include <functional>
 #include <memory>
+#include <map>
 
 #include <pvxs/version.h>
 #include "srvcommon.h"
@@ -102,6 +103,9 @@ struct PVXS_API StaticSource
     StaticSource& add(const std::string& name, const SharedPV& pv);
     //! Remove a single name
     StaticSource& remove(const std::string& name);
+
+    typedef std::map<std::string, SharedPV> list_t;
+    list_t list() const;
 
     struct Impl;
 private:

--- a/src/pvxs/source.h
+++ b/src/pvxs/source.h
@@ -228,6 +228,8 @@ struct PVXS_API Source {
     /** A Client is requesting a list of Channel names which we may claim.
      */
     virtual List onList();
+
+    virtual void show(std::ostream& strm);
 };
 
 }} // namespace pvxs::server

--- a/src/pvxs/source.h
+++ b/src/pvxs/source.h
@@ -60,28 +60,31 @@ struct PVXS_API MonitorControlOp : public OpBase {
     virtual ~MonitorControlOp();
 
 protected:
-    virtual bool doPost(Value&& val, bool maybe, bool force) =0;
+    virtual bool doPost(const Value& val, bool maybe, bool force) =0;
 public:
 
     //! Add a new entry to the monitor queue.
     //! If nFree()<=0 the output queue will be over-filled with this element.
     //! Returns @code nFree()>0u @endcode
-    bool forcePost(Value&& val) {
-        return doPost(std::move(val), false, true);
+    //! @warning Caller must not modify the Value
+    bool forcePost(const Value& val) {
+        return doPost(val, false, true);
     }
 
     //! Add a new entry to the monitor queue.
     //! If nFree()<=0 this element will be "squashed" to the last element in the queue
     //! Returns @code nFree()>0u @endcode
-    bool post(Value&& val) {
-        return doPost(std::move(val), false, false);
+    //! @warning Caller must not modify the Value
+    bool post(const Value& val) {
+        return doPost(val, false, false);
     }
 
     //! Add a new entry to the monitor queue.
     //! If nFree()<=0 return false and take no other action
     //! Returns @code nFree()>0u @endcode
-    bool tryPost(Value&& val) {
-        return doPost(std::move(val), true, false);
+    //! @warning Caller must not modify the Value
+    bool tryPost(const Value& val) {
+        return doPost(val, true, false);
     }
 
     //! Signal to subscriber that this subscription will not yield any further events.

--- a/src/pvxs/util.h
+++ b/src/pvxs/util.h
@@ -111,6 +111,47 @@ public:
 PVXS_API
 std::map<std::string, size_t> instanceSnapshot();
 
+//! See Indented
+struct indent {};
+
+PVXS_API
+std::ostream& operator<<(std::ostream& strm, const indent&);
+
+//! Scoped indentation for std::ostream
+struct PVXS_API Indented {
+    explicit Indented(std::ostream& strm, int depth=1);
+    Indented(const Indented&) = delete;
+    Indented(Indented&& o) noexcept
+        :strm(o.strm)
+        ,depth(o.depth)
+    {
+        o.strm = nullptr;
+        o.depth = 0;
+    }
+    ~Indented();
+private:
+    std::ostream *strm;
+    int depth;
+};
+
+struct PVXS_API Detailed {
+    explicit Detailed(std::ostream& strm, int lvl=1);
+    Detailed(const Detailed&) = delete;
+    Detailed(Detailed&& o) noexcept
+        :strm(o.strm)
+        ,lvl(o.lvl)
+    {
+        o.strm = nullptr;
+        o.lvl = 0;
+    }
+    ~Detailed();
+    static
+    int level(std::ostream& strm);
+private:
+    std::ostream *strm;
+    int lvl;
+};
+
 } // namespace pvxs
 
 #endif // PVXS_UTIL_H

--- a/src/serverconn.cpp
+++ b/src/serverconn.cpp
@@ -287,8 +287,10 @@ void ServerConn::cleanup()
     }
     for(auto& pair : chanBySID) {
         pair.second->state = ServerChan::Destroy;
-        if(pair.second->onClose)
-            pair.second->onClose("");
+        if(pair.second->onClose) {
+            auto fn(std::move(pair.second->onClose));
+            fn("");
+        }
     }
 }
 

--- a/src/serverconn.cpp
+++ b/src/serverconn.cpp
@@ -279,21 +279,16 @@ void ServerConn::cleanup()
 {
     log_debug_printf(connsetup, "Client %s Cleanup TCP Connection\n", peerName.c_str());
 
-    auto it = iface->server->connections.find(this);
-    if(it!=iface->server->connections.end()) {
-        auto self = std::move(it->second);
-        iface->server->connections.erase(it);
+    iface->server->connections.erase(this);
 
-        for(auto& pair : self->opByIOID) {
-            if(pair.second->onClose)
-                pair.second->onClose("");
-        }
-        for(auto& pair : self->chanBySID) {
-            if(pair.second->onClose)
-                pair.second->onClose("");
-        }
-
-        // delete this
+    for(auto& pair : opByIOID) {
+        if(pair.second->onClose)
+            pair.second->onClose("");
+    }
+    for(auto& pair : chanBySID) {
+        pair.second->state = ServerChan::Destroy;
+        if(pair.second->onClose)
+            pair.second->onClose("");
     }
 }
 

--- a/src/serverconn.h
+++ b/src/serverconn.h
@@ -51,6 +51,8 @@ struct ServerOp
     ServerOp(const ServerOp&) = delete;
     ServerOp& operator=(const ServerOp&) = delete;
     virtual ~ServerOp() =0;
+
+    virtual void show(std::ostream& strm) const =0;
 };
 
 struct ServerChannelControl : public server::ChannelControl

--- a/src/serverconn.h
+++ b/src/serverconn.h
@@ -28,7 +28,6 @@ namespace pvxs {namespace impl {
 struct ServIface;
 struct ServerConn;
 struct ServerChan;
-struct ServerChan;
 
 // base for tracking in-progress operations.  cf. ServerConn::opByIOID and ServerChan::opByIOID
 struct ServerOp

--- a/src/serverget.cpp
+++ b/src/serverget.cpp
@@ -126,6 +126,19 @@ struct ServerGPR : public ServerOp
         }
     }
 
+    void show(std::ostream& strm) const override final
+    {
+        switch(cmd) {
+#define CASE(CMD) case CMD_ ## CMD : strm<< #CMD "\n"; break
+        CASE(GET);
+        CASE(PUT);
+        CASE(RPC);
+#undef CASE
+        default:
+            strm<<"CMD"<<std::hex<<cmd<<"\n";
+        }
+    }
+
     pva_app_msg_t cmd;
     uint8_t subcmd; // valid when state==Executing or Creating
     bool lastRequest=false;

--- a/src/serverget.cpp
+++ b/src/serverget.cpp
@@ -378,8 +378,9 @@ void ServerConn::handle_GPR(pva_app_msg_t cmd)
 
         auto& chan = lookupSID(sid);
 
-        if(opByIOID.find(ioid)!=opByIOID.end()) {
-            log_err_printf(connsetup, "Client %s reuses existing ioid %u\n", peerName.c_str(), unsigned(ioid));
+        if(!chan || opByIOID.find(ioid)!=opByIOID.end()) {
+            log_err_printf(connsetup, "Client %s reuses existing sid %u ioid %u\n",
+                           peerName.c_str(), unsigned(sid), unsigned(ioid));
             bev.reset();
             return;
         }

--- a/src/serverintrospect.cpp
+++ b/src/serverintrospect.cpp
@@ -154,8 +154,9 @@ void ServerConn::handle_GET_FIELD()
 
     auto& chan = lookupSID(sid);
 
-    if(opByIOID.find(ioid)!=opByIOID.end()) {
-        log_err_printf(connsetup, "Client %s reuses existing ioid %d\n", peerName.c_str(), unsigned(ioid));
+    if(!chan || opByIOID.find(ioid)!=opByIOID.end()) {
+        log_err_printf(connsetup, "Client %s reuses existing sid %u ioid %d\n",
+                       peerName.c_str(), unsigned(sid), unsigned(ioid));
         return;
     }
 

--- a/src/serverintrospect.cpp
+++ b/src/serverintrospect.cpp
@@ -49,6 +49,11 @@ struct ServerIntrospect : public ServerOp
         ch->opByIOID.erase(ioid);
     }
 
+    void show(std::ostream& strm) const override final
+    {
+        strm<<"INFO\n";
+    }
+
     INST_COUNTER(ServerIntrospect);
 };
 

--- a/src/servermon.cpp
+++ b/src/servermon.cpp
@@ -209,7 +209,7 @@ struct ServerMonitorControl : public server::MonitorControlOp
         finish();
     }
 
-    virtual bool doPost(Value&& val, bool maybe, bool force) override final
+    virtual bool doPost(const Value& val, bool maybe, bool force) override final
     {
         auto mon(op.lock());
         if(!mon)
@@ -221,7 +221,7 @@ struct ServerMonitorControl : public server::MonitorControlOp
             throw std::logic_error("Type change not allowed in post().  Recommend pvxs::Value::cloneEmpty()");
 
         if((mon->queue.size() < mon->limit) || force || !val) {
-            mon->queue.push_back(std::move(val));
+            mon->queue.push_back(val);
 
         } else if(!maybe) {
             // squash

--- a/src/servermon.cpp
+++ b/src/servermon.cpp
@@ -195,6 +195,11 @@ struct MonitorOp : public ServerOp,
             scheduled = true;
         }
     }
+
+    void show(std::ostream& strm) const override final
+    {
+        strm<<"MONITOR\n";
+    }
 };
 
 struct ServerMonitorSetup;

--- a/src/sharedarray.cpp
+++ b/src/sharedarray.cpp
@@ -234,6 +234,9 @@ void convertArr(ArrayType dtype,       void *dbase,
                 ArrayType stype, const void *sbase,
                 size_t count)
 {
+    if(count==0u)
+        return; // ignore type when no elements.  (conflating empty array with Null array)
+
     switch (stype) {
     case ArrayType::Bool:
         switch(dtype) {
@@ -458,7 +461,7 @@ void convertArr(ArrayType dtype,       void *dbase,
     case ArrayType::Null:
         break;
     }
-    throw NoConvert();
+    throw NoConvert(SB()<<"No array conversion from "<<stype<<" to "<<dtype);
 }
 
 shared_array<void> copyAs(ArrayType dtype, ArrayType stype, const void *sbase, size_t count)

--- a/src/sharedarray.cpp
+++ b/src/sharedarray.cpp
@@ -62,6 +62,31 @@ size_t elementSize(ArrayType type)
     throw std::logic_error("Invalid ArrayType");
 }
 
+shared_array<void> allocArray(ArrayType type, size_t count)
+{
+    switch(type) {
+#define CASE(CODE, TYPE) case ArrayType::CODE: return shared_array<TYPE>(count).castTo<void>()
+    CASE(Bool, bool);
+    CASE(UInt8, uint8_t);
+    CASE(UInt16, uint16_t);
+    CASE(UInt32, uint32_t);
+    CASE(UInt64, uint64_t);
+    CASE(Int8, int8_t);
+    CASE(Int16, int16_t);
+    CASE(Int32, int32_t);
+    CASE(Int64, int64_t);
+    CASE(Float32, float);
+    CASE(Float64, double);
+    CASE(String, std::string);
+    CASE(Value, Value);
+#undef CASE
+    case ArrayType::Null:
+        break;
+    }
+
+    throw std::logic_error("Invalid ArrayType");
+}
+
 namespace detail {
 
 namespace {

--- a/src/sharedpv.cpp
+++ b/src/sharedpv.cpp
@@ -69,7 +69,7 @@ SharedPV SharedPV::buildMailbox()
             }
         }
 
-        pv.post(std::move(val));
+        pv.post(val);
 
         op->reply();
     });
@@ -381,7 +381,7 @@ void SharedPV::close()
     }
 }
 
-void SharedPV::post(Value&& val)
+void SharedPV::post(const Value& val)
 {
     if(!impl)
         throw std::logic_error("Empty SharedPV");
@@ -397,8 +397,13 @@ void SharedPV::post(Value&& val)
 
     impl->current.assign(val);
 
+    if(impl->subscribers.empty())
+        return;
+
+    auto copy(val.clone());
+
     for(auto& sub : impl->subscribers) {
-        sub->post(val.clone());
+        sub->post(copy);
     }
 }
 

--- a/src/sharedpv.cpp
+++ b/src/sharedpv.cpp
@@ -441,7 +441,7 @@ Value SharedPV::fetch() const
 
 struct StaticSource::Impl : public Source
 {
-    RWLock lock;
+    mutable RWLock lock;
 
     list_t pvs;
     decltype (List::names) list;
@@ -487,6 +487,17 @@ struct StaticSource::Impl : public Source
         ret.dynamic = false;
 
         return ret;
+    }
+
+    virtual void show(std::ostream& strm) override final
+    {
+        strm<<"StaticProvider";
+
+        auto G(lock.lockReader());
+        for(auto& pair : pvs) {
+            strm<<"\n"<<indent{}<<pair.first;
+            // TODO: details for SharedPV
+        }
     }
 };
 

--- a/src/sharedpv.cpp
+++ b/src/sharedpv.cpp
@@ -407,7 +407,7 @@ void SharedPV::post(const Value& val)
     }
 }
 
-void SharedPV::fetch(Value& val)
+void SharedPV::fetch(Value& val) const
 {
     if(!impl)
         throw std::logic_error("Empty SharedPV");
@@ -416,6 +416,20 @@ void SharedPV::fetch(Value& val)
 
     if(impl->current) {
         val.assign(impl->current);
+    } else {
+        throw std::logic_error("open() first");
+    }
+}
+
+Value SharedPV::fetch() const
+{
+    if(!impl)
+        throw std::logic_error("Empty SharedPV");
+
+    Guard G(impl->lock);
+
+    if(impl->current) {
+        return impl->current.clone();
     } else {
         throw std::logic_error("open() first");
     }

--- a/src/sharedpv.cpp
+++ b/src/sharedpv.cpp
@@ -370,10 +370,8 @@ void SharedPV::close()
     {
         Guard G(impl->lock);
 
-        if(!impl->current)
-            return; // ignore double close()
-
-        impl->current = Value();
+        if(impl->current)
+            impl->current = Value();
 
         impl->subscribers.clear();
         channels = std::move(impl->channels);

--- a/src/sharedpv.cpp
+++ b/src/sharedpv.cpp
@@ -439,7 +439,7 @@ struct StaticSource::Impl : public Source
 {
     RWLock lock;
 
-    std::map<std::string, SharedPV> pvs;
+    list_t pvs;
     decltype (List::names) list;
 
     virtual void onSearch(Search &op) override
@@ -538,6 +538,20 @@ StaticSource& StaticSource::remove(const std::string& name)
     pv.close();
 
     return *this;
+}
+
+StaticSource::list_t StaticSource::list() const
+{
+    list_t ret;
+
+    if(!impl)
+        throw std::logic_error("Empty StaticSource");
+
+    {
+        auto G(impl->lock.lockReader());
+
+        return impl->pvs; // copies map
+    }
 }
 
 } // namespace server

--- a/src/sharedpv.cpp
+++ b/src/sharedpv.cpp
@@ -506,6 +506,20 @@ std::shared_ptr<Source> StaticSource::source() const
     return impl;
 }
 
+void StaticSource::close()
+{
+    if(!impl)
+        throw std::logic_error("Empty StaticSource");
+
+    {
+        auto G(impl->lock.lockReader());
+
+        for(auto& pair : impl->pvs) {
+            pair.second.close();
+        }
+    }
+}
+
 StaticSource& StaticSource::add(const std::string& name, const SharedPV &pv)
 {
     if(!impl)

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -80,6 +80,31 @@ StoreType TypeCode::storedAs() const
     }
 }
 
+ArrayType TypeCode::arrayType() const
+{
+    switch(code) {
+#define CASE(ATYPE, TYPE) case TypeCode::TYPE: return ArrayType::ATYPE
+    CASE(Bool, BoolA);
+    CASE(Int8, Int8A);
+    CASE(Int16, Int16A);
+    CASE(Int32, Int32A);
+    CASE(Int64, Int64A);
+    CASE(UInt8, UInt8A);
+    CASE(UInt16, UInt16A);
+    CASE(UInt32, UInt32A);
+    CASE(UInt64, UInt64A);
+    CASE(Float32, Float32A);
+    CASE(Float64, Float64A);
+    CASE(String, StringA);
+    CASE(Value, StructA);
+    CASE(Value, UnionA);
+    CASE(Value, AnyA);
+#undef CASE
+    default:
+        throw std::logic_error("TypeCode can not be mapped to ArrayType");
+    }
+}
+
 const char* TypeCode::name() const
 {
     switch(code) {

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -94,7 +94,7 @@ StoreType TypeCode::storedAs() const
         return StoreType::Compound;
 
     } else {
-        throw std::logic_error("TypeCode::storedAs() not map");
+        throw std::logic_error(SB()<<"TypeCode::storedAs("<<(*this)<<") not map");
     }
 }
 
@@ -163,6 +163,17 @@ const char* TypeCode::name() const
 #undef CASE
     }
     return "\?\?\?_t";
+}
+
+std::ostream& operator<<(std::ostream& strm, TypeCode c)
+{
+    auto name = c.name();
+    if(name[0]!='?') {
+        strm<<name;
+    } else {
+        strm<<"TypeCode(0x"<<std::hex<<(unsigned)c.code<<")";
+    }
+    return strm;
 }
 
 void Member::Helper::node_validate(const Member* parent, const std::string& id, TypeCode code)

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -282,7 +282,8 @@ void Member::Helper::copy_tree(const FieldDesc* desc, Member& node)
 TypeDef::TypeDef(const Value& val)
 {
     if(val.desc) {
-        auto root(std::make_shared<Member>(val.desc->code, val.desc->id));
+        auto root(std::make_shared<Member>(val.desc->code, ""));
+        root->id = val.desc->id;
 
         Member::Helper::copy_tree(val.desc, *root);
 

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -12,6 +12,24 @@
 
 namespace pvxs {
 
+std::ostream& operator<<(std::ostream& strm, StoreType c)
+{
+    const char* name = "<\?\?\?>";
+    switch(c) {
+#define CASE(CODE) case StoreType::CODE: name = #CODE; break
+    CASE(Null);
+    CASE(Bool);
+    CASE(Real);
+    CASE(Integer);
+    CASE(UInteger);
+    CASE(String);
+    CASE(Compound);
+    CASE(Array);
+#undef CASE
+    }
+    return strm<<name;
+}
+
 struct Member::Helper {
     static
     void node_validate(const Member* parent, const std::string& id, TypeCode code);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -386,30 +386,51 @@ namespace pvxs {namespace impl {
 template<>
 double parseTo<double>(const std::string& s) {
     size_t idx=0, L=s.size();
-    double ret = std::stod(s, &idx);
+    double ret;
+    try {
+        ret = std::stod(s, &idx);
+    }catch(std::invalid_argument& e) {
+        throw NoConvert(SB()<<"Invalid input : \""<<escape(s)<<"\"");
+    }catch(std::out_of_range& e) {
+        throw NoConvert(SB()<<"Out of range : \""<<escape(s)<<"\"");
+    }
     for(; idx<L && isspace(s[idx]); idx++) {}
     if(idx<L)
-        throw std::invalid_argument(SB()<<"Extraneous charactors after double: \""<<escape(s)<<"\"");
+        NoConvert(SB()<<"Extraneous characters after double: \""<<escape(s)<<"\"");
     return ret;
 }
 
 template<>
 uint64_t parseTo<uint64_t>(const std::string& s) {
     size_t idx=0, L=s.size();
-    unsigned long long ret = std::stoull(s, &idx, 0);
+    unsigned long long ret;
+    try {
+        ret = std::stoull(s, &idx, 0);
+    }catch(std::invalid_argument& e) {
+        throw NoConvert(SB()<<"Invalid input : \""<<escape(s)<<"\"");
+    }catch(std::out_of_range& e) {
+        throw NoConvert(SB()<<"Out of range : \""<<escape(s)<<"\"");
+    }
     for(; idx<L && isspace(s[idx]); idx++) {}
     if(idx<L)
-        throw std::invalid_argument(SB()<<"Extraneous charactors after integer: \""<<escape(s)<<"\"");
+        throw NoConvert(SB()<<"Extraneous characters after integer: \""<<escape(s)<<"\"");
     return ret;
 }
 
 template<>
 int64_t parseTo<int64_t>(const std::string& s) {
     size_t idx=0, L=s.size();
-    long long ret = std::stoll(s, &idx, 0);
+    long long ret;
+    try {
+        ret = std::stoll(s, &idx, 0);
+    }catch(std::invalid_argument& e) {
+        throw NoConvert(SB()<<"Invalid input : \""<<escape(s)<<"\"");
+    }catch(std::out_of_range& e) {
+        throw NoConvert(SB()<<"Out of range : \""<<escape(s)<<"\"");
+    }
     for(; idx<L && isspace(s[idx]); idx++) {}
     if(idx<L)
-        throw std::invalid_argument(SB()<<"Extraneous charactors after unsigned: \""<<escape(s)<<"\"");
+        throw NoConvert(SB()<<"Extraneous characters after unsigned: \""<<escape(s)<<"\"");
     return ret;
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -344,9 +344,8 @@ void SockAddr::setPort(unsigned short port)
 
 void SockAddr::setAddress(const char *name, unsigned short port)
 {
-    SockAddr temp;
-    int templen = sizeof(temp.store);
-    if(evutil_parse_sockaddr_port(name, &temp->sa, &templen))
+    SockAddr temp(AF_INET);
+    if(aToIPAddr(name, port, &temp->in))
         throw std::runtime_error(std::string("Unable to parse as IP addresss: ")+name);
     if(temp.port()==0)
         temp.setPort(port);

--- a/src/utilpvt.h
+++ b/src/utilpvt.h
@@ -48,8 +48,6 @@ struct SB {
     SB& operator<<(const T& i) { strm<<i; return *this; }
 };
 
-void indent(std::ostream& strm, unsigned level);
-
 namespace idetail {
 template <typename I>
 struct Range {

--- a/src/utilpvt.h
+++ b/src/utilpvt.h
@@ -253,7 +253,7 @@ struct InstCounter
 
 #define INST_COUNTER(KLASS) InstCounter<&cnt_ ## KLASS> instances
 
-#define CASE(KLASS) extern std::atomic<size_t> cnt_ ## KLASS
+#define CASE(KLASS) PVXS_API extern std::atomic<size_t> cnt_ ## KLASS
 
 CASE(StructTop);
 

--- a/test/mcat.cpp
+++ b/test/mcat.cpp
@@ -152,7 +152,7 @@ int main(int argc, char* argv[])
     src->name = argv[optind];
     src->fname = argv[optind+1];
 
-    auto serv = server::Config::from_env()
+    auto serv = server::Config::fromEnv()
             .build()
             .addSource("mcat", src);
 

--- a/test/testconfig.cpp
+++ b/test/testconfig.cpp
@@ -33,10 +33,10 @@ void testParse()
 
     client::Config conf;
     try {
-        conf = client::Config::from_env();
-        testPass("client::Config::from_env()");
+        conf = client::Config::fromEnv();
+        testPass("client::Config::fromEnv()");
     }catch(std::exception& e){
-        testFail("client::Config::from_env() %s : %s", typeid (e).name(), e.what());
+        testFail("client::Config::fromEnv() %s : %s", typeid (e).name(), e.what());
     }
 
     if(testEq(conf.addressList.size(), 2u)) {

--- a/test/testdata.cpp
+++ b/test/testdata.cpp
@@ -273,6 +273,26 @@ void testConvertScalar(const Store& store, const Inout& inout)
     testEq(inout, cont.as<Inout>())<<typeid(Store).name()<<"->"<<typeid(Inout).name();
 }
 
+template<typename Store, typename In, typename Out>
+void testConvertScalar2(const Store& store, const In& in, const Out& out)
+{
+    testShow()<<__func__<<"("<<store<<","<<in<<","<<out<<")";
+
+    typedef impl::ScalarMap<Store> store_t;
+
+    auto cont = TypeDef(store_t::code).create();
+
+    try {
+        cont.from(in);
+    }catch(std::exception& e){
+        testCase(false)<<"Error storing as "<<typeid (Store).name()<<" "<<in<<" : "<<e.what();
+    }
+
+    testEq(store, cont.as<Store>())<<typeid(Store).name();
+
+    testEq(out, cont.as<Out>())<<typeid(Store).name()<<"->"<<typeid(Out).name();
+}
+
 void testAssignSimilar()
 {
     testShow()<<__func__;
@@ -342,7 +362,7 @@ void testAssignSimilar()
 
 MAIN(testdata)
 {
-    testPlan(99);
+    testPlan(111);
     testSetup();
     testTraverse();
     testAssign();
@@ -351,6 +371,7 @@ MAIN(testdata)
     testIterStruct();
     testIterUnion();
     testPvRequest();
+
     testConvertScalar<double, bool>(1.0, true);
     testConvertScalar<double, bool>(0.0, false);
     testConvertScalar<double, uint32_t>(5.0, 5);
@@ -365,6 +386,10 @@ MAIN(testdata)
     testConvertScalar<int32_t, int32_t>(-5, -5);
     testConvertScalar<int32_t, double>(-5, -5.0);
     testConvertScalar<int32_t, std::string>(-5, "-5");
+    testConvertScalar<uint32_t, int32_t>(0xffffffff, -1);
+    testConvertScalar<uint32_t, int16_t>(0xffffffff, -1);
+    testConvertScalar<uint16_t, int32_t>(0xffff, 0xffff);
+    testConvertScalar<uint32_t, int32_t>(0x80000000, -2147483648);
     testConvertScalar<std::string, bool>("true", true);
     testConvertScalar<std::string, bool>("false", false);
     testConvertScalar<std::string, uint32_t>("5", 5);
@@ -372,6 +397,10 @@ MAIN(testdata)
     testConvertScalar<std::string, int32_t>("-5", -5);
     testConvertScalar<std::string, double>("-5", -5.0);
     testConvertScalar<std::string, std::string>("-5", "-5");
+
+    testConvertScalar2<int32_t, uint64_t, int64_t>(-2147483648, 0x80000000, -2147483648);
+    testConvertScalar2<int32_t, uint64_t, int64_t>(0, 0x100000000llu, -0);
+
     testAssignSimilar();
     cleanup_for_valgrind();
     return testDone();

--- a/test/testdata.cpp
+++ b/test/testdata.cpp
@@ -14,7 +14,6 @@
 #include "utilpvt.h"
 #include "pvaproto.h"
 #include "dataimpl.h"
-#include "pvrequest.h"
 
 using namespace pvxs;
 namespace  {
@@ -205,54 +204,6 @@ void testIterUnion()
     }
 }
 
-void testPvRequest()
-{
-    namespace M = members;
-
-    testDiag("%s", __func__);
-
-    auto def = nt::NTScalar{TypeCode::String}.build();
-    auto val = def.create();
-    testShow()<<val;
-
-    {
-        auto rdef = TypeDef(TypeCode::Struct, {
-                                M::Struct("field", {})
-                            });
-
-        auto mask = request2mask(Value::Helper::desc(val), rdef.create());
-
-        testEq(mask, BitMask({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 10u));
-    }
-
-    {
-        auto rdef = TypeDef(TypeCode::Struct, {
-                                M::Struct("field", {
-                                    M::Struct("value", {}),
-                                })
-                            });
-
-        auto mask = request2mask(Value::Helper::desc(val), rdef.create());
-
-        testEq(mask, BitMask({0, 1}, 10u));
-    }
-
-    {
-        auto rdef = TypeDef(TypeCode::Struct, {
-                                M::Struct("field", {
-                                    M::Struct("timeStamp", {}),
-                                    M::Struct("alarm", {
-                                        M::Struct("status", {}),
-                                    }),
-                                })
-                            });
-
-        auto mask = request2mask(Value::Helper::desc(val), rdef.create());
-
-        testEq(mask, BitMask({0, 2, 4, 6, 7, 8, 9}, 10u));
-    }
-}
-
 template<typename Store, typename Inout>
 void testConvertScalar(const Store& store, const Inout& inout)
 {
@@ -362,7 +313,7 @@ void testAssignSimilar()
 
 MAIN(testdata)
 {
-    testPlan(111);
+    testPlan(108);
     testSetup();
     testTraverse();
     testAssign();
@@ -370,7 +321,6 @@ MAIN(testdata)
     testName();
     testIterStruct();
     testIterUnion();
-    testPvRequest();
 
     testConvertScalar<double, bool>(1.0, true);
     testConvertScalar<double, bool>(0.0, false);

--- a/test/testdata.cpp
+++ b/test/testdata.cpp
@@ -67,6 +67,29 @@ void testAssign()
     testOk1(!val["alarm"].isMarked(true, false));
 }
 
+void testAssignUnion()
+{
+    testDiag("%s", __func__);
+
+    auto val = TypeDef(TypeCode::Union, {
+                           members::UInt16("u16"),
+                           members::String("s"),
+                       }).create();
+
+    val["->u16"] = 42;
+    testEq(val.as<std::string>(), "42");
+    val["->s"] = "test";
+    testEq(val.as<std::string>(), "test");
+
+    testEq(val.nameOf(val["->"]), "s");
+
+    testThrows<std::invalid_argument>([&val](){
+        val["->u16"] = "hello";
+    });
+
+    //val = nullptr;
+}
+
 void testName()
 {
     testDiag("%s", __func__);
@@ -314,10 +337,11 @@ void testAssignSimilar()
 
 MAIN(testdata)
 {
-    testPlan(93);
+    testPlan(97);
     testSetup();
     testTraverse();
     testAssign();
+    testAssignUnion();
     testName();
     testIterStruct();
     testIterUnion();

--- a/test/testdata.cpp
+++ b/test/testdata.cpp
@@ -83,11 +83,16 @@ void testAssignUnion()
 
     testEq(val.nameOf(val["->"]), "s");
 
+    val = unselect;
+
+    testFalse(val["->"].valid());
+
     testThrows<std::invalid_argument>([&val](){
         val["->u16"] = "hello";
     });
 
-    //val = nullptr;
+    // previous selection succeeds, but assignment fails
+    testTrue(val["->"].valid());
 }
 
 void testName()

--- a/test/testdata.cpp
+++ b/test/testdata.cpp
@@ -149,14 +149,14 @@ void testIterStruct()
     val.unmark();
     val["alarm"].mark();
 
-    testMarked(4u)<<"mark sub-struct";
+    testMarked(4u)<<"mark alarm sub-struct";
 
     val.unmark();
     val["value"].mark(); // 1 field
     val["alarm.status"].mark(); // 1 field
     val["timeStamp"].mark(); // 4 fields (struct node and 3x leaves)
 
-    testMarked(6u)<<"mark sub-struct";
+    testMarked(6u)<<"mark multiple sub-struct";
 }
 
 void testIterUnion()
@@ -342,7 +342,7 @@ void testAssignSimilar()
 
 MAIN(testdata)
 {
-    testPlan(97);
+    testPlan(99);
     testSetup();
     testTraverse();
     testAssign();

--- a/test/testdata.cpp
+++ b/test/testdata.cpp
@@ -27,6 +27,10 @@ void testTraverse()
 
     testOk1(!top["<"].valid());
 
+    testThrows<std::runtime_error>([&top](){
+        top.lookup("<");
+    });
+
     {
         auto top2 = top["value<"];
         testOk1(top.equalType(top2));
@@ -310,7 +314,7 @@ void testAssignSimilar()
 
 MAIN(testdata)
 {
-    testPlan(92);
+    testPlan(93);
     testSetup();
     testTraverse();
     testAssign();

--- a/test/testdata.cpp
+++ b/test/testdata.cpp
@@ -397,8 +397,12 @@ MAIN(testdata)
     testConvertScalar<std::string, int32_t>("-5", -5);
     testConvertScalar<std::string, double>("-5", -5.0);
     testConvertScalar<std::string, std::string>("-5", "-5");
-
+#ifdef _MSC_VER
+    // MSVC reads back 2147483648
+    testTodoBegin("MSVC differs");
+#endif
     testConvertScalar2<int32_t, uint64_t, int64_t>(-2147483648, 0x80000000, -2147483648);
+    testTodoEnd();
     testConvertScalar2<int32_t, uint64_t, int64_t>(0, 0x100000000llu, -0);
 
     testAssignSimilar();

--- a/test/testdata.cpp
+++ b/test/testdata.cpp
@@ -87,7 +87,7 @@ void testAssignUnion()
 
     testFalse(val["->"].valid());
 
-    testThrows<std::invalid_argument>([&val](){
+    testThrows<NoConvert>([&val](){
         val["->u16"] = "hello";
     });
 

--- a/test/testget.cpp
+++ b/test/testget.cpp
@@ -45,7 +45,7 @@ struct Tester {
 
     ~Tester()
     {
-        if(cli.use_count()!=1u)
+        if(cli.use_count()>1u)
             testAbort("Tester Context leak");
     }
 
@@ -173,6 +173,17 @@ struct Tester {
 
         testOk1(!done.wait(2.1));
     }
+
+    void orphan()
+    {
+        testShow()<<__func__;
+
+        auto op = cli.get("nonexistent").exec();
+
+        // clear Context to orphan in-progress operation
+        cli = client::Context();
+        op.reset();
+    }
 };
 
 struct ErrorSource : public server::Source
@@ -253,6 +264,7 @@ MAIN(testget)
     Tester().lazy();
     Tester().timeout();
     Tester().cancel();
+    Tester().orphan();
     testError(false);
     testError(true);
     cleanup_for_valgrind();

--- a/test/testget.cpp
+++ b/test/testget.cpp
@@ -106,13 +106,13 @@ struct Tester {
         std::atomic<bool> onFC{false}, onLD{false};
         epicsEvent done;
 
-        mbox.onFirstConnect([this, &onFC](){
+        mbox.onFirstConnect([this, &onFC](server::SharedPV&){
             testShow()<<"In onFirstConnect()";
 
             mbox.open(initial);
             onFC.store(true);
         });
-        mbox.onLastDisconnect([this, &onLD, &done](){
+        mbox.onLastDisconnect([this, &onLD, &done](server::SharedPV&){
             testShow()<<"In onLastDisconnect";
             mbox.close();
             onLD.store(true);

--- a/test/testinfo.cpp
+++ b/test/testinfo.cpp
@@ -149,6 +149,17 @@ struct Tester {
 
         testOk1(!done.wait(2.1));
     }
+
+    void orphan()
+    {
+        testShow()<<__func__;
+
+        auto op = cli.info("nonexistent").exec();
+
+        // clear Context to orphan in-progress operation
+        cli = client::Context();
+        op.reset();
+    }
 };
 
 struct ErrorSource : public server::Source
@@ -213,6 +224,7 @@ MAIN(testinfo)
     Tester().lazy();
     Tester().timeout();
     Tester().cancel();
+    Tester().orphan();
     testError();
     return testDone();
 }

--- a/test/testinfo.cpp
+++ b/test/testinfo.cpp
@@ -82,13 +82,13 @@ struct Tester {
         std::atomic<bool> onFC{false}, onLD{false};
         epicsEvent done;
 
-        mbox.onFirstConnect([this, &onFC](){
+        mbox.onFirstConnect([this, &onFC](server::SharedPV&){
             testShow()<<"In onFirstConnect()";
 
             mbox.open(initial);
             onFC.store(true);
         });
-        mbox.onLastDisconnect([this, &onLD, &done](){
+        mbox.onLastDisconnect([this, &onLD, &done](server::SharedPV&){
             testShow()<<"In onLastDisconnect";
             mbox.close();
             onLD.store(true);

--- a/test/testmon.cpp
+++ b/test/testmon.cpp
@@ -48,7 +48,7 @@ struct BasicTest {
 
     ~BasicTest()
     {
-        if(cli.use_count()!=1u)
+        if(cli.use_count()>1u)
             testAbort("Tester Context leak");
     }
 
@@ -83,6 +83,17 @@ struct BasicTest {
             }
         }
         return ret;
+    }
+
+    void orphan()
+    {
+        testShow()<<__func__;
+
+        auto op = cli.monitor("nonexistent").exec();
+
+        // clear Context to orphan in-progress operation
+        cli = client::Context();
+        op.reset();
     }
 };
 
@@ -253,6 +264,7 @@ MAIN(testmon)
     testPlan(22);
     testSetup();
     logger_config_env();
+    BasicTest().orphan();
     TestLifeCycle().testBasic(true);
     TestLifeCycle().testBasic(false);
     TestLifeCycle().testSecond();

--- a/test/testmon.cpp
+++ b/test/testmon.cpp
@@ -68,7 +68,7 @@ struct BasicTest {
     {
         auto update(initial.cloneEmpty());
         update["value"] = v;
-        mbox.post(std::move(update));
+        mbox.post(update);
     }
 
     static
@@ -183,7 +183,7 @@ struct TestLifeCycle : public BasicTest
 
         auto update(initial.cloneEmpty());
         update["value"] = 39;
-        mbox2.post(std::move(update));
+        mbox2.post(update);
 
         if(auto val = pop(sub2, evt2)) {
             testEq(val["value"].as<int32_t>(), 39);
@@ -224,9 +224,9 @@ struct TestReconn : public BasicTest
 
         testFalse(sub->pop())<<"No events after Disconnect";
 
-        mbox.post(std::move(initial
-                            .cloneEmpty()
-                            .update("value", 15)));
+        mbox.post(initial
+                  .cloneEmpty()
+                  .update("value", 15));
 
         errlogFlush();
         testDiag("Starting server");

--- a/test/testput.cpp
+++ b/test/testput.cpp
@@ -174,6 +174,19 @@ struct Tester : public TesterBase
 
         testOk1(!done.wait(2.1));
     }
+
+    void orphan()
+    {
+        testShow()<<__func__;
+
+        auto op = cli.put("nonexistent")
+                     .set("value", "foo")
+                     .exec();
+
+        // clear Context to orphan in-progress operation
+        cli = client::Context();
+        op.reset();
+    }
 };
 
 struct TestPutBuilder : public TesterBase
@@ -326,6 +339,7 @@ MAIN(testput)
     Tester().lazy();
     Tester().timeout();
     Tester().cancel();
+    Tester().orphan();
     TestPutBuilder().testSet();
     testRO();
     testError();

--- a/test/testput.cpp
+++ b/test/testput.cpp
@@ -107,13 +107,13 @@ struct Tester : public TesterBase
         std::atomic<bool> onFC{false}, onLD{false};
         epicsEvent done;
 
-        mbox.onFirstConnect([this, &onFC](){
+        mbox.onFirstConnect([this, &onFC](server::SharedPV&){
             testShow()<<"In onFirstConnect()";
 
             mbox.open(initial);
             onFC.store(true);
         });
-        mbox.onLastDisconnect([this, &onLD, &done](){
+        mbox.onLastDisconnect([this, &onLD, &done](server::SharedPV&){
             testShow()<<"In onLastDisconnect";
             mbox.close();
             onLD.store(true);

--- a/test/testpvreq.cpp
+++ b/test/testpvreq.cpp
@@ -17,10 +17,59 @@
 #include <pvxs/sharedArray.h>
 #include <pvxs/client.h>
 #include <pvxs/nt.h>
-#include "utilpvt.h"
+#include "dataimpl.h"
+#include "pvrequest.h"
 
 namespace {
 using namespace pvxs;
+
+void testPvRequest()
+{
+    namespace M = members;
+
+    testDiag("%s", __func__);
+
+    auto def = nt::NTScalar{TypeCode::String}.build();
+    auto val = def.create();
+    testShow()<<val;
+
+    {
+        auto rdef = TypeDef(TypeCode::Struct, {
+                                M::Struct("field", {})
+                            });
+
+        auto mask = request2mask(Value::Helper::desc(val), rdef.create());
+
+        testEq(mask, BitMask({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 10u));
+    }
+
+    {
+        auto rdef = TypeDef(TypeCode::Struct, {
+                                M::Struct("field", {
+                                    M::Struct("value", {}),
+                                })
+                            });
+
+        auto mask = request2mask(Value::Helper::desc(val), rdef.create());
+
+        testEq(mask, BitMask({0, 1}, 10u));
+    }
+
+    {
+        auto rdef = TypeDef(TypeCode::Struct, {
+                                M::Struct("field", {
+                                    M::Struct("timeStamp", {}),
+                                    M::Struct("alarm", {
+                                        M::Struct("status", {}),
+                                    }),
+                                })
+                            });
+
+        auto mask = request2mask(Value::Helper::desc(val), rdef.create());
+
+        testEq(mask, BitMask({0, 2, 4, 6, 7, 8, 9}, 10u));
+    }
+}
 
 struct TestBuilder : client::detail::CommonBuilder<TestBuilder, client::detail::PRBase>
 {
@@ -300,9 +349,10 @@ void testArgs()
 
 MAIN(testpvreq)
 {
-    testPlan(27);
+    testPlan(30);
     testSetup();
     logger_config_env();
+    testPvRequest();
     testEmpty();
     testAssemble();
     testParseEmpty();

--- a/test/testpvreq.cpp
+++ b/test/testpvreq.cpp
@@ -71,6 +71,36 @@ void testPvRequest()
     }
 }
 
+void testPvMask()
+{
+    auto val = nt::NTScalar{TypeCode::String}.create();
+
+    auto rdef = TypeDef(TypeCode::Struct, {
+                            members::Struct("field", {
+                                members::Struct("value", {}),
+                            })
+                        });
+
+    auto mask = request2mask(Value::Helper::desc(val), rdef.create());
+
+    testFalse(testmask(val, mask));
+
+    val["alarm.status"].mark();
+    testFalse(testmask(val, mask));
+
+    val["value"].mark();
+    testTrue(testmask(val, mask));
+
+    val["alarm.status"].unmark();
+    testTrue(testmask(val, mask));
+
+    val.unmark();
+    testFalse(testmask(val, mask));
+
+    val.mark();
+    testTrue(testmask(val, mask));
+}
+
 struct TestBuilder : client::detail::CommonBuilder<TestBuilder, client::detail::PRBase>
 {
     TestBuilder()
@@ -349,10 +379,11 @@ void testArgs()
 
 MAIN(testpvreq)
 {
-    testPlan(30);
+    testPlan(36);
     testSetup();
     logger_config_env();
     testPvRequest();
+    testPvMask();
     testEmpty();
     testAssemble();
     testParseEmpty();

--- a/test/testpvreq.cpp
+++ b/test/testpvreq.cpp
@@ -28,10 +28,6 @@ struct TestBuilder : client::detail::CommonBuilder<TestBuilder, client::detail::
         :client::detail::CommonBuilder<TestBuilder, client::detail::PRBase>(nullptr, "")
     {}
 
-    Value makeReq() const {
-        return _buildReq();
-    }
-
     template<typename T>
     TestBuilder& set(const std::string& name, const T& val, bool required=true) {
         const typename impl::StoreAs<T>::store_t& norm(impl::StoreTransform<T>::in(val));
@@ -52,7 +48,7 @@ void testEmpty()
 {
     testShow()<<__func__;
 
-    auto req = TestBuilder().makeReq();
+    auto req = client::Context::request().build();
 
     testShow()<<req;
     testStrEq(std::string(SB()<<req),
@@ -67,12 +63,12 @@ void testAssemble()
 {
     testShow()<<__func__;
 
-    auto req = TestBuilder()
+    auto req = client::Context::request()
             .field("foo")
             .field("bar.baz")
             .record("abc", "xyz")
             .record("pipeline", true)
-            .makeReq();
+            .build();
 
     testShow()<<req;
     testStrEq(std::string(SB()<<req),
@@ -99,9 +95,9 @@ void testParse1()
 {
     testShow()<<__func__;
 
-    auto req = TestBuilder()
+    auto req = client::Context::request()
             .pvRequest("field(foo)field(bar.baz)record[abc=xyz]record[pipeline=true]")
-            .makeReq();
+            .build();
 
     testShow()<<req;
     testStrEq(std::string(SB()<<req),
@@ -128,9 +124,9 @@ void testParse2()
 {
     testShow()<<__func__;
 
-    auto req = TestBuilder()
+    auto req = client::Context::request()
             .pvRequest("field(foo,bar.baz)record[abc=xyz,pipeline=true]")
-            .makeReq();
+            .build();
 
     testShow()<<req;
     testStrEq(std::string(SB()<<req),
@@ -170,7 +166,7 @@ void testValid()
 
     for(auto& pvr : valid) {
         try {
-            testCase(true)<<pvr<<"\n"<<TestBuilder().pvRequest(pvr).makeReq();
+            testCase(true)<<pvr<<"\n"<<client::Context::request().pvRequest(pvr).build();
         }catch(std::exception& e){
             testCase(false)<<pvr<<" : "<<typeid(e).name()<<" : "<<e.what();
         }
@@ -198,9 +194,9 @@ void testError()
     for(auto& pvr : errors) {
 
         testThrows<std::runtime_error>([&pvr](){
-            auto req = TestBuilder()
+            auto req = client::Context::request()
                     .pvRequest(pvr)
-                    .makeReq();
+                    .build();
             testShow()<<req;
         })<<pvr;
     }

--- a/test/testpvreq.cpp
+++ b/test/testpvreq.cpp
@@ -91,6 +91,46 @@ void testAssemble()
     );
 }
 
+void testParseEmpty()
+{
+    testShow()<<__func__;
+
+    auto req = client::Context::request()
+            .pvRequest("")
+            .build();
+
+    testShow()<<req;
+    testStrEq(std::string(SB()<<req),
+        "struct {\n"
+        "    struct {\n"
+        "    } field\n"
+        "}\n"
+    );
+}
+
+void testParseValue()
+{
+    testShow()<<__func__;
+
+    auto req = client::Context::request()
+            .pvRequest("field(value)")
+            .build();
+
+    testShow()<<req;
+    testStrEq(std::string(SB()<<req),
+        "struct {\n"
+        "    struct {\n"
+        "        struct {\n"
+        "        } value\n"
+        "    } field\n"
+        "    struct {\n"
+        "        struct {\n"
+        "        } _options\n"
+        "    } record\n"
+        "}\n"
+    );
+}
+
 void testParse1()
 {
     testShow()<<__func__;
@@ -260,11 +300,13 @@ void testArgs()
 
 MAIN(testpvreq)
 {
-    testPlan(25);
+    testPlan(27);
     testSetup();
     logger_config_env();
     testEmpty();
     testAssemble();
+    testParseEmpty();
+    testParseValue();
     testParse1();
     testParse2();
     testValid();

--- a/test/testrpc.cpp
+++ b/test/testrpc.cpp
@@ -201,6 +201,17 @@ struct Tester {
         testEq(result["query.a"].as<int32_t>(), 5);
         testEq(result["query.b"].as<std::string>(), "hello");
     }
+
+    void orphan()
+    {
+        testShow()<<__func__;
+
+        auto op = cli.rpc("nonexistent").exec();
+
+        // clear Context to orphan in-progress operation
+        cli = client::Context();
+        op.reset();
+    }
 };
 
 } // namespace
@@ -216,6 +227,7 @@ MAIN(testrpc)
     Tester().cancel();
     Tester().error();
     Tester().builder();
+    Tester().orphan();
     cleanup_for_valgrind();
     return testDone();
 }

--- a/test/testshared.cpp
+++ b/test/testshared.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include <pvxs/sharedArray.h>
+#include <pvxs/data.h>
 
 #include <pvxs/unittest.h>
 #include <epicsUnitTest.h>
@@ -136,6 +137,30 @@ void testComplex()
     testEq(*X[0], 4u);
 }
 
+void testValue()
+{
+    testDiag("%s", __func__);
+
+    auto top = TypeDef(TypeCode::UInt32).create();
+
+    shared_array<Value> A(allocArray(ArrayType::Value, 2u).castTo<Value>());
+
+    A[0] = top.cloneEmpty();
+    A[0] = 1u;
+    A[1] = top.cloneEmpty();
+    A[1] = 2u;
+
+    auto varr(A.castTo<void>());
+    testEq(varr.size(), 2u);
+    testEq(varr.original_type(), ArrayType::Value);
+
+    auto B(varr.castTo<Value>());
+
+    testEq(B.size(), 2u);
+    testEq(B.at(0).as<uint32_t>(), 1u);
+    testEq(B.at(1).as<uint32_t>(), 2u);
+}
+
 void testCast()
 {
     testDiag("%s", __func__);
@@ -242,7 +267,7 @@ void testConvert()
 
 MAIN(testshared)
 {
-    testPlan(110);
+    testPlan(115);
     testSetup();
     testEmpty<void>();
     testEmpty<const void>();
@@ -255,6 +280,7 @@ MAIN(testshared)
     testFreeze();
     testFreezeError();
     testComplex();
+    testValue();
     testCast();
     testFromVector();
     testElemAlloc();

--- a/test/testshared.cpp
+++ b/test/testshared.cpp
@@ -196,6 +196,20 @@ void testFromVector()
     testEq(V.size(), 3u);
 }
 
+void testElemAlloc()
+{
+    testDiag("%s", __func__);
+
+    testEq(elementSize(ArrayType::UInt8), 1u);
+    testEq(elementSize(ArrayType::UInt16), 2u);
+    testEq(elementSize(ArrayType::UInt32), 4u);
+    testEq(elementSize(ArrayType::UInt64), 8u);
+
+    auto varr = allocArray(ArrayType::UInt32, 3u);
+    testEq(varr.size(), 3u);
+    testEq(varr.original_type(), ArrayType::UInt32);
+}
+
 void testConvert()
 {
     testDiag("%s", __func__);
@@ -228,7 +242,7 @@ void testConvert()
 
 MAIN(testshared)
 {
-    testPlan(104);
+    testPlan(110);
     testSetup();
     testEmpty<void>();
     testEmpty<const void>();
@@ -243,6 +257,7 @@ MAIN(testshared)
     testComplex();
     testCast();
     testFromVector();
+    testElemAlloc();
     testConvert();
     return testDone();
 }

--- a/test/testshared.cpp
+++ b/test/testshared.cpp
@@ -196,11 +196,39 @@ void testFromVector()
     testEq(V.size(), 3u);
 }
 
+void testConvert()
+{
+    testDiag("%s", __func__);
+
+    static_assert (detail::CaptureCode<uint32_t>::code!=detail::CaptureCode<uint16_t>::code, "");
+
+    testArrEq(shared_array<uint32_t>({1u, 2u, 0xffffffffu}).convertTo<uint32_t>(),
+              shared_array<uint32_t>({1u, 2u, 0xffffffffu}));
+
+    testArrEq(shared_array<uint32_t>({1u, 2u, 0xffffffffu}).convertTo<uint16_t>(),
+              shared_array<uint16_t>({1u, 2u, 0xffffu}));
+
+    testArrEq(shared_array<uint32_t>({1u, 2u, 0xffffffffu}).convertTo<int32_t>(),
+              shared_array<int32_t>({1, 2, -1}));
+
+    testArrEq(shared_array<uint32_t>({1u, 2u, 0xffffffffu}).convertTo<int16_t>(),
+              shared_array<int16_t>({1, 2, -1}));
+
+    testArrEq(shared_array<int32_t>({1, 2, -1}).convertTo<uint32_t>(),
+              shared_array<uint32_t>({1u, 2u, 0xffffffffu}));
+
+    testArrEq(shared_array<int32_t>({1, 2, -1}).convertTo<double>(),
+              shared_array<double>({1.0, 2.0, -1.0}));
+
+    testArrEq(shared_array<int32_t>({1, 2, -1}).convertTo<std::string>(),
+              shared_array<std::string>({"1", "2", "-1"}));
+}
+
 } // namespace
 
 MAIN(testshared)
 {
-    testPlan(97);
+    testPlan(104);
     testSetup();
     testEmpty<void>();
     testEmpty<const void>();
@@ -215,5 +243,6 @@ MAIN(testshared)
     testComplex();
     testCast();
     testFromVector();
+    testConvert();
     return testDone();
 }

--- a/test/testtype.cpp
+++ b/test/testtype.cpp
@@ -28,6 +28,31 @@ void showSize()
 #undef CASE
 }
 
+void testCode()
+{
+    testDiag("%s()", __func__);
+
+    testEq(TypeCode{TypeCode::UInt8}.size(), 1u);
+    testEq(TypeCode{TypeCode::UInt16}.size(), 2u);
+    testEq(TypeCode{TypeCode::UInt32}.size(), 4u);
+    testEq(TypeCode{TypeCode::UInt64}.size(), 8u);
+
+    testEq(TypeCode{TypeCode::UInt8A}.size(), 1u);
+    testEq(TypeCode{TypeCode::UInt16A}.size(), 2u);
+    testEq(TypeCode{TypeCode::UInt32A}.size(), 4u);
+    testEq(TypeCode{TypeCode::UInt64A}.size(), 8u);
+
+    testEq(TypeCode{TypeCode::Int8}.size(), 1u);
+    testEq(TypeCode{TypeCode::Int16}.size(), 2u);
+    testEq(TypeCode{TypeCode::Int32}.size(), 4u);
+    testEq(TypeCode{TypeCode::Int64}.size(), 8u);
+
+    testEq(TypeCode{TypeCode::Int8A}.size(), 1u);
+    testEq(TypeCode{TypeCode::Int16A}.size(), 2u);
+    testEq(TypeCode{TypeCode::Int32A}.size(), 4u);
+    testEq(TypeCode{TypeCode::Int64A}.size(), 8u);
+}
+
 void testBasic()
 {
     testDiag("%s()", __func__);
@@ -460,9 +485,10 @@ void testFormat()
 
 MAIN(testtype)
 {
-    testPlan(29);
+    testPlan(45);
     testSetup();
     showSize();
+    testCode();
     testBasic();
     testTypeDef();
     testTypeDefDynamic();

--- a/test/testtype.cpp
+++ b/test/testtype.cpp
@@ -347,6 +347,30 @@ void testTypeDefDynamic()
     }
 }
 
+void testTypeDefAppend()
+{
+    testDiag("%s()", __func__);
+
+    auto base = TypeDef(TypeCode::Struct, "epics:nt/NTDummy:0.0", {
+                            members::UInt32("A"),
+                        }).create();
+
+    auto sub = TypeDef(base);
+    sub += {
+            members::UInt32("B"),
+    };
+
+    auto amend = sub.create();
+
+    testEq(base.id(), "epics:nt/NTDummy:0.0");
+    testEq(base["A"].type(), TypeCode::UInt32);
+    testEq(base["B"].type(), TypeCode::Null);
+
+    testEq(amend.id(), "epics:nt/NTDummy:0.0");
+    testEq(amend["A"].type(), TypeCode::UInt32);
+    testEq(amend["B"].type(), TypeCode::UInt32);
+}
+
 //! Returns the frankenstruct
 Value neckBolt()
 {
@@ -485,13 +509,14 @@ void testFormat()
 
 MAIN(testtype)
 {
-    testPlan(45);
+    testPlan(51);
     testSetup();
     showSize();
     testCode();
     testBasic();
     testTypeDef();
     testTypeDefDynamic();
+    testTypeDefAppend();
     testFormat();
     cleanup_for_valgrind();
     return testDone();

--- a/tools/call.cpp
+++ b/tools/call.cpp
@@ -119,7 +119,7 @@ int main(int argc, char *argv[])
             query[pair.first] = pair.second;
         }
 
-        auto ctxt = client::Config::from_env().build();
+        auto ctxt = client::Config::fromEnv().build();
 
         if(verbose)
             std::cout<<"Effective config\n"<<ctxt.config();

--- a/tools/get.cpp
+++ b/tools/get.cpp
@@ -96,7 +96,7 @@ int main(int argc, char *argv[])
             }
         }
 
-        auto ctxt = client::Config::from_env().build();
+        auto ctxt = client::Config::fromEnv().build();
 
         if(verbose)
             std::cout<<"Effective config\n"<<ctxt.config();

--- a/tools/info.cpp
+++ b/tools/info.cpp
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
             }
         }
 
-        auto ctxt = client::Config::from_env().build();
+        auto ctxt = client::Config::fromEnv().build();
 
         if(verbose)
             std::cout<<"Effective config\n"<<ctxt.config();

--- a/tools/monitor.cpp
+++ b/tools/monitor.cpp
@@ -94,7 +94,7 @@ int main(int argc, char *argv[])
             }
         }
 
-        auto ctxt = client::Config::from_env().build();
+        auto ctxt = client::Config::fromEnv().build();
 
         if(verbose)
             std::cout<<"Effective config\n"<<ctxt.config();

--- a/tools/put.cpp
+++ b/tools/put.cpp
@@ -106,7 +106,7 @@ int main(int argc, char *argv[])
         }
 
 
-        auto ctxt = client::Config::from_env().build();
+        auto ctxt = client::Config::fromEnv().build();
 
         if(verbose)
             std::cout<<"Effective config\n"<<ctxt.config();


### PR DESCRIPTION
I'm creating this PR mainly as a venue to mention several (I think minor) API changes in the big set of changes driven by my porting [P4P](https://github.com/mdavidsaver/p4p) to use PVXS (including the gateway component).  It will likely remain open until I'm closer to finalizing that project.

So far these are:

* Several argument types change from `Value&&` to `const Value&`.  This should not be a breaking change as an implicit cast is possible.  It may trigger warnings about now unnecessary `std::move()`.  This includes: `SharedPV::post()` and friends, and several of the client `*Builder` methods.

* The signature of the `SharedPV` callbacks `onFirstConnect()` and `onLastDisconnect()` are changed to add a new argument `SharedPV&`.  This is added for consistency with the `onPut()` and `onRPC()` callbacks which already had this convience.

* The `server::Config` and `client::Config` classes add a new static method `fromEnv()` which is identical to the `from_env()` method.  The original `from_env()` will later be removed.

* Some exception types have changed.  I've tried to maintain consistency, but likely haven't been 100% successful.

* Setting an invalid hostname in `$EPICS_PVAS_INTF_ADDR_LIST` changes from a warning to an error.  It didn't seem friendly to silently bind to `0.0.0.0` when a user is explicitly asking for something else.