### PR TITLE
bug fix: 'numeric_limits' is not a member of 'std'

### DIFF
--- a/src/conn.cpp
+++ b/src/conn.cpp
@@ -4,6 +4,8 @@
  * in file LICENSE that is included with this distribution.
  */
 
+#include <limits>
+
 #include <epicsAssert.h>
 
 #include <pvxs/log.h>


### PR DESCRIPTION
src/conn.cpp: add limits header to fix 'numeric_limits' is not a member of 'std'