### PR TITLE
Support for multicast and IPv6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -546,6 +546,11 @@ def define_DSOS(self):
 
     src_pvxs = [os.path.join('src', src) for src in src_pvxs]
 
+    if OS_CLASS=='WIN32':
+        src_pvxs += ['src/os/WIN32/osdSockExt.cpp']
+    else:
+        src_pvxs += ['src/os/default/osdSockExt.cpp']
+
     event_libs = []
     if OS_CLASS=='WIN32':
         event_libs = ['ws2_32','shell32','advapi32','bcrypt','iphlpapi']

--- a/setup.py
+++ b/setup.py
@@ -542,6 +542,7 @@ def define_DSOS(self):
         'clientintrospect.cpp',
         'clientget.cpp',
         'clientmon.cpp',
+        'clientdiscover.cpp',
     ]
 
     src_pvxs = [os.path.join('src', src) for src in src_pvxs]

--- a/src/Makefile
+++ b/src/Makefile
@@ -106,6 +106,7 @@ LIB_SRCS += clientconn.cpp
 LIB_SRCS += clientintrospect.cpp
 LIB_SRCS += clientget.cpp
 LIB_SRCS += clientmon.cpp
+LIB_SRCS += clientdiscover.cpp
 
 LIB_LIBS += Com
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -86,6 +86,8 @@ LIB_SRCS += nt.cpp
 LIB_SRCS += evhelper.cpp
 LIB_SRCS += udp_collector.cpp
 
+LIB_SRCS += osdSockExt.cpp
+
 LIB_SRCS += config.cpp
 LIB_SRCS += conn.cpp
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -468,8 +468,7 @@ Value buildCAMethod()
 }
 
 ContextImpl::ContextImpl(const Config& conf, const evbase& tcp_loop)
-    :canIPv6(evsocket::canIPv6())
-    ,ifmap(IfaceMap::instance())
+    :ifmap(IfaceMap::instance())
     ,effective(conf)
     ,caMethod(buildCAMethod())
     ,searchTx4(AF_INET, SOCK_DGRAM, 0)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -519,10 +519,8 @@ ContextImpl::ContextImpl(const Config& conf, const evbase& tcp_loop)
             log_err_printf(setup, "%s  Ignoring %s\n", e.what(), addr.c_str());
             continue;
         }
-        auto top = ntohl(saddr->in.sin_addr.s_addr)>>24u;
-        auto ismcast = top>224 && top<239;
-        bool isbcast = bcasts.find(saddr)!=bcasts.end();
-        auto isucast = !isbcast && !ismcast;
+        // if !bcast and !mcast
+        auto isucast = bcasts.find(saddr)==bcasts.end() && !saddr.isMCast();
 
         log_info_printf(io, "Searching to %s%s\n", saddr.tostring().c_str(), (isucast?" unicast":""));
         searchDest.emplace_back(saddr, isucast);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -479,7 +479,7 @@ ContextImpl::ContextImpl(const Config& conf, const evbase& tcp_loop)
 
     searchBuckets.resize(nBuckets);
 
-    std::set<SockAddr> bcasts;
+    std::set<SockAddr, SockAddrOnlyLess> bcasts;
     for(auto& addr : searchTx.broadcasts()) {
         addr.setPort(0u);
         bcasts.insert(addr);
@@ -517,7 +517,7 @@ ContextImpl::ContextImpl(const Config& conf, const evbase& tcp_loop)
         }
         auto top = ntohl(saddr->in.sin_addr.s_addr)>>24u;
         auto ismcast = top>224 && top<239;
-        bool isbcast = bcasts.find(saddr.withPort(0))!=bcasts.end(); // TODO: exclude port
+        bool isbcast = bcasts.find(saddr)!=bcasts.end();
         auto isucast = !isbcast && !ismcast;
 
         log_info_printf(io, "Searching to %s%s\n", saddr.tostring().c_str(), (isucast?" unicast":""));

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -750,14 +750,13 @@ bool ContextImpl::onSearch()
 {
     searchMsg.resize(0x10000);
     SockAddr src;
-    uint32_t ndrop = 0u;
 
-    osiSocklen_t alen = src.size();
-    const int nrx = recvfromx(searchTx.sock, (char*)&searchMsg[0], searchMsg.size()-1, &src->sa, &alen, &ndrop);
+    recvfromx rx{searchTx.sock, (char*)&searchMsg[0], searchMsg.size()-1, &src};
+    const int nrx = rx.call();
 
-    if(nrx>=0 && ndrop!=0 && prevndrop!=ndrop) {
-        log_debug_printf(io, "UDP search reply buffer overflow %u -> %u\n", unsigned(prevndrop), unsigned(ndrop));
-        prevndrop = ndrop;
+    if(nrx>=0 && rx.ndrop!=0 && prevndrop!=rx.ndrop) {
+        log_debug_printf(io, "UDP search reply buffer overflow %u -> %u\n", unsigned(prevndrop), unsigned(rx.ndrop));
+        prevndrop = rx.ndrop;
     }
 
     if(nrx<0) {

--- a/src/clientdiscover.cpp
+++ b/src/clientdiscover.cpp
@@ -1,0 +1,138 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * pvxs is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+
+#include <pvxs/log.h>
+#include <pvxs/nt.h>
+#include "utilpvt.h"
+#include "clientimpl.h"
+
+DEFINE_LOGGER(setup, "pvxs.client.setup");
+DEFINE_LOGGER(io, "pvxs.client.io");
+
+namespace pvxs {
+namespace client {
+
+Discovery::Discovery(const std::shared_ptr<ContextImpl> &context)
+    :OperationBase (Operation::Discover, context->tcp_loop)
+    ,context(context)
+{}
+
+Discovery::~Discovery() {
+    if(loop.assertInRunningLoop())
+        _cancel(true);
+}
+
+bool Discovery::cancel()
+{
+    decltype (notify) junk;
+    bool ret;
+    loop.call([this, &junk, &ret](){
+        ret = _cancel(false);
+        junk = std::move(notify);
+        // leave opByIOID for GC
+    });
+    return ret;
+}
+
+bool Discovery::_cancel(bool implicit) {
+    bool active = running;
+
+    if(active) {
+        context->discoverers.erase(this);
+        running = false;
+    }
+    return active;
+}
+
+// unused for this special case
+void Discovery::_reExecGet(std::function<void (Result &&)> &&resultcb) {}
+void Discovery::_reExecPut(const Value &arg, std::function<void (Result &&)> &&resultcb) {}
+void Discovery::createOp() {}
+void Discovery::disconnected(const std::shared_ptr<OperationBase> &self) {}
+
+std::shared_ptr<Operation> DiscoverBuilder::exec()
+{
+    if(!ctx)
+        throw std::logic_error("NULL Builder");
+    if(!_fn)
+        throw std::logic_error("Callback required");
+
+    auto context(ctx->impl->shared_from_this());
+    auto ping(_ping);
+
+    auto op(std::make_shared<Discovery>(context));
+    op->notify = std::move(_fn);
+
+    auto syncCancel(_syncCancel);
+    std::shared_ptr<Discovery> external(op.get(), [op, syncCancel](Discovery*) mutable {
+        // (maybe) user thread
+        auto loop(op->context->tcp_loop);
+        auto temp(std::move(op));
+        loop.tryInvoke(syncCancel, std::bind([](std::shared_ptr<Discovery>& op){
+                           // on worker
+                           op->context->discoverers.erase(op.get());
+
+                       }, std::move(temp)));
+    });
+
+    // setup timer to send discovery
+
+    context->tcp_loop.dispatch([op, context, ping]() {
+
+        bool first = context->discoverers.empty();
+
+        context->discoverers[op.get()] = op;
+        op->running = true;
+
+        if(first && ping) {
+            log_debug_printf(setup, "Starting Discover%s", "\n");
+
+            context->tickSearch(true);
+        }
+    });
+
+    return external;
+}
+
+void ContextImpl::serverEvent(const Discovered &evt)
+{
+    for(auto& pair : discoverers) {
+        if(auto dis = pair.second.lock()) {
+            try {
+                dis->notify(evt);
+            } catch(std::exception& e) {
+                log_exc_printf(io, "Unhandled exception during Discovery callback : %s\n", e.what());
+            }
+        }
+    }
+}
+
+std::ostream& operator<<(std::ostream& strm, const Discovered& serv)
+{
+    char prefix[64];
+
+    serv.time.strftime(prefix, sizeof(prefix), "%Y-%m-%dT%H:%M:%S.%9f");
+    strm<<prefix;
+
+    switch(serv.event) {
+    case client::Discovered::Online:
+        strm<<" ONLINE ";
+        break;
+    case client::Discovered::Timeout:
+        strm<<" OFFLINE";
+        break;
+    }
+
+    strm<<" guid: "<<serv.guid
+        <<" proto: "<<escape(serv.proto)
+        <<" server: "<<serv.server
+        <<" via: "<<serv.peer;
+
+    return strm;
+}
+
+} // namespace client
+} // namespace pvxs

--- a/src/clientimpl.h
+++ b/src/clientimpl.h
@@ -226,6 +226,8 @@ private:
 struct ContextImpl : public std::enable_shared_from_this<ContextImpl>
 {
     SockAttach attach;
+    const bool canIPv6;
+    IfaceMap& ifmap;
 
     // "const" after ctor
     Config effective;
@@ -235,7 +237,7 @@ struct ContextImpl : public std::enable_shared_from_this<ContextImpl>
     uint32_t nextCID=0x12345678;
     uint32_t prevndrop = 0u;
 
-    evsocket searchTx;
+    evsocket searchTx4, searchTx6;
     uint16_t searchRxPort;
 
     std::vector<ServerGUID> ignoreServerGUIDs;
@@ -256,7 +258,7 @@ struct ContextImpl : public std::enable_shared_from_this<ContextImpl>
     std::vector<uint8_t> searchMsg;
 
     // search destination address and whether to set the unicast flag
-    std::vector<std::pair<SockAddr, bool>> searchDest;
+    std::vector<std::pair<SockEndpoint, bool>> searchDest;
 
     size_t currentBucket = 0u;
     std::vector<std::list<std::weak_ptr<Channel>>> searchBuckets;
@@ -274,7 +276,7 @@ struct ContextImpl : public std::enable_shared_from_this<ContextImpl>
     std::vector<std::pair<SockAddr, std::shared_ptr<Connection>>> nameServers;
 
     evbase tcp_loop;
-    const evevent searchRx;
+    const evevent searchRx4, searchRx6;
     const evevent searchTimer;
 
     // beacon handling done on UDP worker.
@@ -302,7 +304,7 @@ struct ContextImpl : public std::enable_shared_from_this<ContextImpl>
 
     void onBeacon(const UDPManager::Beacon& msg);
 
-    bool onSearch();
+    bool onSearch(evutil_socket_t fd);
     static void onSearchS(evutil_socket_t fd, short evt, void *raw);
     void tickSearch(bool discover);
     static void tickSearchS(evutil_socket_t fd, short evt, void *raw);

--- a/src/clientimpl.h
+++ b/src/clientimpl.h
@@ -226,7 +226,6 @@ private:
 struct ContextImpl : public std::enable_shared_from_this<ContextImpl>
 {
     SockAttach attach;
-    const bool canIPv6;
     IfaceMap& ifmap;
 
     // "const" after ctor

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -433,15 +433,25 @@ Config& Config::applyEnv()
     return *this;
 }
 
-Config Config::isolated()
+Config Config::isolated(int family)
 {
     Config ret;
 
     ret.udp_port = 0u;
     ret.tcp_port = 0u;
-    ret.interfaces.emplace_back("127.0.0.1");
     ret.auto_beacon = false;
-    ret.beaconDestinations.emplace_back("127.0.0.1");
+    switch(family) {
+    case AF_INET:
+        ret.interfaces.emplace_back("127.0.0.1");
+        ret.beaconDestinations.emplace_back("127.0.0.1");
+        break;
+    case AF_INET6:
+        ret.interfaces.emplace_back("::1");
+        ret.beaconDestinations.emplace_back("::1");
+        break;
+    default:
+        throw std::logic_error(SB()<<"Unsupported address family "<<family);
+    }
 
     return ret;
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -487,6 +487,17 @@ void Config::expand()
         ifaces.emplace_back(SockAddr::any(AF_INET));
     }
 
+    auto& ifmap = IfaceMap::instance();
+
+    for(auto& ep : ifaces) {
+        if(!ep.addr.isMCast()) {}
+        else if(!ep.iface.empty()) {
+            ifaces.emplace_back(ifmap.address_of(ep.iface));
+        } else {
+            ifaces.emplace_back(SockAddr::any(ep.addr.family()));
+        }
+    }
+
     if(auto_beacon) {
         // use interface list add ipv4 broadcast addresses to beaconDestinations.
         // 0.0.0.0 -> adds all bcasts

--- a/src/conn.cpp
+++ b/src/conn.cpp
@@ -48,7 +48,7 @@ size_t ConnBase::enqueueTxBody(pva_app_msg_t cmd)
                         uint32_t(blen)},
              hostBE);
     auto err = evbuffer_add_buffer(tx, txBody.get());
-    assert(!err);
+    assert(!err); // could only fail if frozen/pinned, which is not the case
     statTx += 8u + blen;
     return 8u + blen;
 }

--- a/src/describe.cpp
+++ b/src/describe.cpp
@@ -103,7 +103,7 @@ std::ostream& target_information(std::ostream& strm)
 #endif
 
         auto localaddr(osiLocalAddr(dummy.sock));
-        strm<<indent{}<<"osiLocalAddr() -> "<<SockAddr(&localaddr.sa, sizeof(localaddr)).tostring()<<"\n";
+        strm<<indent{}<<"osiLocalAddr() -> "<<SockAddr(&localaddr.sa).tostring()<<"\n";
 
         strm<<indent{}<<"osiSockDiscoverBroadcastAddresses() ->\n";
         Indented J(strm);

--- a/src/evhelper.cpp
+++ b/src/evhelper.cpp
@@ -88,7 +88,7 @@ struct ThreadEvent
             } else {
                 // race
                 epicsThreadPrivateDelete(temp);
-                id = pvt.load();
+                assert(id);
             }
         }
 

--- a/src/evhelper.cpp
+++ b/src/evhelper.cpp
@@ -365,6 +365,8 @@ bool evbase::assertInRunningLoop() const
     throw std::logic_error("Not in running evbase worker");
 }
 
+bool evsocket::canIPv6;
+
 evsocket::evsocket(int af, evutil_socket_t sock)
     :sock(sock)
     ,af(af)
@@ -636,7 +638,7 @@ std::vector<SockAddr> evsocket::broadcasts(const SockAddr* match) const
 #  define EAFNOSUPPORT WSAESOCKTNOSUPPORT
 #endif
 
-bool evsocket::canIPv6()
+bool evsocket::init_canIPv6()
 {
     try {
         evsocket sock(AF_INET6, SOCK_DGRAM, 0);

--- a/src/evhelper.cpp
+++ b/src/evhelper.cpp
@@ -138,7 +138,7 @@ struct evbase::Pvt : public epicsThreadRunable
                 epicsThreadGetStackSize(epicsThreadStackBig),
                 prio)
     {
-        epicsThreadOnce(&evthread_once, &evthread_init, nullptr);
+        threadOnce(&evthread_once, &evthread_init, nullptr);
 
         worker.start();
         start_sync.wait();

--- a/src/evhelper.cpp
+++ b/src/evhelper.cpp
@@ -366,6 +366,7 @@ bool evbase::assertInRunningLoop() const
 }
 
 bool evsocket::canIPv6;
+evsocket::ipstack_t evsocket::ipstack;
 
 evsocket::evsocket(int af, evutil_socket_t sock)
     :sock(sock)

--- a/src/evhelper.h
+++ b/src/evhelper.h
@@ -11,6 +11,8 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <map>
+#include <set>
 
 #include <event2/event.h>
 #include <event2/buffer.h>
@@ -19,6 +21,8 @@
 
 #include <pvxs/version.h>
 #include <utilpvt.h>
+
+#include <epicsTime.h>
 
 #include "pvaproto.h"
 
@@ -228,6 +232,18 @@ struct PVXS_API evsocket
 
     //! wraps osiSockDiscoverBroadcastAddresses()
     std::vector<SockAddr> broadcasts(const SockAddr* match=nullptr) const;
+};
+
+struct PVXS_API IfaceMap {
+    IfaceMap();
+
+    // return true if ifindex is valid, and addr is one of the addresses currently assigned to it.
+    bool has_address(int64_t ifindex, const SockAddr& addr);
+
+    void refresh();
+
+    std::map<int64_t, std::set<SockAddr, SockAddrOnlyLess>> info;
+    epicsTime updated;
 };
 
 } // namespace impl

--- a/src/evhelper.h
+++ b/src/evhelper.h
@@ -214,10 +214,15 @@ struct PVXS_API evsocket
 
     ~evsocket();
 
+    SockAddr sockname() const;
+
     // test validity
     inline operator bool() const { return sock!=-1; }
 
+    void bind(const SockAddr& addr) const;
     void bind(SockAddr& addr) const;
+
+    void listen(int backlog) const;
 
     void set_broadcast(bool b) const;
 

--- a/src/evhelper.h
+++ b/src/evhelper.h
@@ -251,6 +251,13 @@ struct PVXS_API evsocket
     bool canIPv6;
 
     static bool init_canIPv6();
+
+    enum ipstack_t {
+        Linsock,
+        Winsock,
+        GenericBSD,
+    };
+    static ipstack_t ipstack;
 };
 
 struct PVXS_API IfaceMap {

--- a/src/evhelper.h
+++ b/src/evhelper.h
@@ -248,7 +248,9 @@ struct PVXS_API evsocket
     std::vector<SockAddr> broadcasts(const SockAddr* match=nullptr) const;
 
     static
-    bool canIPv6();
+    bool canIPv6;
+
+    static bool init_canIPv6();
 };
 
 struct PVXS_API IfaceMap {

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -243,7 +243,7 @@ Level logger::init()
         if(this->lvl.compare_exchange_strong(lvl, Level::Warn)) {
             // logger now has default config of Level::Err
             // we will fully initialize
-            epicsThreadOnce(&logger_once, &logger_prepare, nullptr);
+            threadOnce(&logger_once, &logger_prepare, nullptr);
             assert(logger_gbl);
 
             Guard G(logger_gbl->lock);
@@ -295,7 +295,7 @@ void xerrlogHexPrintf(const void *buf, size_t buflen)
 
 void logger_level_set(const char *name, int lvl)
 {
-    epicsThreadOnce(&logger_once, &logger_prepare, nullptr);
+    threadOnce(&logger_once, &logger_prepare, nullptr);
     assert(logger_gbl);
 
     Guard G(logger_gbl->lock);
@@ -304,7 +304,7 @@ void logger_level_set(const char *name, int lvl)
 
 void logger_level_clear()
 {
-    epicsThreadOnce(&logger_once, &logger_prepare, nullptr);
+    threadOnce(&logger_once, &logger_prepare, nullptr);
     assert(logger_gbl);
 
     Guard G(logger_gbl->lock);
@@ -317,7 +317,7 @@ void logger_config_env()
     if(!env || !*env)
         return;
 
-    epicsThreadOnce(&logger_once, &logger_prepare, nullptr);
+    threadOnce(&logger_once, &logger_prepare, nullptr);
 
     Guard G(logger_gbl->lock);
 
@@ -366,7 +366,7 @@ namespace pvxs {namespace impl {
 
 void logger_shutdown()
 {
-    epicsThreadOnce(&logger_once, &logger_prepare, nullptr);
+    threadOnce(&logger_once, &logger_prepare, nullptr);
 
     errlogFlush();
 

--- a/src/os/WIN32/osdSockExt.cpp
+++ b/src/os/WIN32/osdSockExt.cpp
@@ -1,0 +1,159 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * pvxs is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+
+#include <winsock2.h>
+#include <iphlpapi.h>
+
+#include "osiSockExt.h"
+
+#include <mswsock.h>
+
+#include <vector>
+
+#include <pvxs/log.h>
+#include "evhelper.h"
+
+#include <epicsThread.h>
+#include <cantProceed.h>
+
+namespace pvxs {
+
+DEFINE_LOGGER(log, "pvxs.util");
+DEFINE_LOGGER(logiface, "pvxs.iface");
+
+static
+LPFN_WSARECVMSG WSARecvMsg;
+
+static
+epicsThreadOnceId oseOnce = EPICS_THREAD_ONCE_INIT;
+
+static
+void oseDoOnce(void*)
+{
+    evsocket dummy(AF_INET, SOCK_DGRAM, 0);
+    GUID guid      = WSAID_WSARECVMSG;
+    DWORD nout;
+
+    if(WSAIoctl(dummy.sock, SIO_GET_EXTENSION_FUNCTION_POINTER,
+                &guid, sizeof(guid),
+                &WSARecvMsg, sizeof(WSARecvMsg),
+                &nout, nullptr, nullptr))
+    {
+        cantProceed("Unable to get &WSARecvMsg: %d", WSAGetLastError());
+    }
+    if(!WSARecvMsg)
+        cantProceed("Unable to get &WSARecvMsg!!");
+}
+
+void osiSockAttachExt()
+{
+    osiSockAttach();
+    epicsThreadOnce(&oseOnce, &oseDoOnce, nullptr);
+}
+
+void enable_SO_RXQ_OVFL(SOCKET sock) {}
+
+void enable_IP_PKTINFO(SOCKET sock)
+{
+    int val = 1;
+    if(setsockopt(sock, IPPROTO_IP, IP_PKTINFO, (char*)&val, sizeof(val)))
+        log_warn_printf(log, "Unable to set IP_PKTINFO: %d\n", SOCKERRNO);
+}
+
+int recvfromx::call()
+{
+    ndrop = 0u;
+    dstif = -1;
+
+    WSAMSG msg{};
+
+    WSABUF iov = {(ULONG)buflen, (char*)buf};
+    msg.lpBuffers = &iov;
+    msg.dwBufferCount = 1u;
+
+    msg.name = &(*src)->sa;
+    msg.namelen = src->size();
+
+    alignas (alignof (WSACMSGHDR)) char cbuf[WSA_CMSG_SPACE(sizeof(in_pktinfo))];
+    msg.Control = {sizeof(cbuf), cbuf};
+
+    DWORD nrx=0u;
+    if(!WSARecvMsg(sock, &msg, &nrx, nullptr, nullptr)) {
+        if(msg.dwFlags & MSG_CTRUNC)
+            log_debug_printf(log, "MSG_CTRUNC %zu, %zu\n", msg.Control.len, sizeof(cbuf));
+
+        for(WSACMSGHDR *hdr = WSA_CMSG_FIRSTHDR(&msg); hdr ; hdr = WSA_CMSG_NXTHDR(&msg, hdr)) {
+            if(hdr->cmsg_level==IPPROTO_IP && hdr->cmsg_type==IP_PKTINFO && hdr->cmsg_len>=WSA_CMSG_LEN(sizeof(in_pktinfo))) {
+                if(dst) {
+                    (*dst)->in.sin_family = AF_INET;
+                    memcpy(&(*dst)->in.sin_addr, WSA_CMSG_DATA(hdr) + offsetof(in_pktinfo, ipi_addr), sizeof(IN_ADDR));
+                }
+
+                decltype(in_pktinfo::ipi_ifindex) idx;
+                memcpy(&idx, WSA_CMSG_DATA(hdr) + offsetof(in_pktinfo, ipi_ifindex), sizeof(idx));
+                dstif = idx;
+            }
+        }
+
+        return nrx;
+
+    } else {
+        return -1;
+    }
+}
+
+namespace impl {
+
+#ifndef GAA_FLAG_INCLUDE_ALL_INTERFACES
+#  define GAA_FLAG_INCLUDE_ALL_INTERFACES 0
+#endif
+
+void IfaceMap::refresh() {
+    std::vector<char> ifaces(1024u);
+    decltype (info) temp;
+
+    {
+        constexpr ULONG flags = GAA_FLAG_SKIP_ANYCAST|GAA_FLAG_SKIP_MULTICAST|GAA_FLAG_SKIP_DNS_SERVER|GAA_FLAG_INCLUDE_ALL_INTERFACES;
+
+        ULONG buflen = ifaces.size();
+        auto err = GetAdaptersAddresses(AF_INET, flags, 0, reinterpret_cast<IP_ADAPTER_ADDRESSES*>(ifaces.data()), &buflen);
+
+        if(err == ERROR_BUFFER_OVERFLOW) {
+            // buflen updated with necessary length, retry
+            ifaces.resize(buflen);
+
+            err = GetAdaptersAddresses(AF_INET, flags, 0, reinterpret_cast<IP_ADAPTER_ADDRESSES*>(ifaces.data()), &buflen);
+        }
+
+        if(err) {
+            log_warn_printf(logiface, "Unable to GetAdaptersAddresses() error=%lld\n", (unsigned long long)err);
+            return;
+        }
+    }
+
+    for(auto iface = reinterpret_cast<const IP_ADAPTER_ADDRESSES*>(ifaces.data()); iface ; iface = iface->Next) {
+        auto& info = temp[iface->IfIndex];
+
+        //TODO: any flags to check?
+
+        for(auto addr = iface->FirstUnicastAddress; addr; addr = addr->Next) {
+
+            if(addr->Address.lpSockaddr->sa_family!=AF_INET)
+                continue;
+
+            auto pair = info.emplace(addr->Address.lpSockaddr, sizeof(sockaddr_in));
+
+            log_debug_printf(logiface, "Found interface %lld \"%s\" w/ %s\n",
+                             (long long)iface->IfIndex, iface->AdapterName, pair.first->tostring().c_str());
+        }
+    }
+
+    info.swap(temp);
+}
+
+} // namespace impl
+
+} // namespace pvxs

--- a/src/os/WIN32/osdSockExt.cpp
+++ b/src/os/WIN32/osdSockExt.cpp
@@ -19,6 +19,16 @@
 #include <epicsThread.h>
 #include <cantProceed.h>
 
+#  include <windows.h>
+#  include <psapi.h>
+
+static
+bool is_wine()
+{
+    HMODULE nt = GetModuleHandle("ntdll.dll");
+    return nt && GetProcAddress(nt, "wine_get_version");
+}
+
 namespace pvxs {
 
 DEFINE_LOGGER(log, "pvxs.util");
@@ -48,6 +58,7 @@ void oseDoOnce(void*)
         cantProceed("Unable to get &WSARecvMsg!!");
 
     evsocket::canIPv6 = evsocket::init_canIPv6();
+    evsocket::ipstack = is_wine() ? evsocket::Linsock : evsocket::Winsock;
 }
 
 void osiSockAttachExt()

--- a/src/os/WIN32/osdSockExt.cpp
+++ b/src/os/WIN32/osdSockExt.cpp
@@ -46,6 +46,8 @@ void oseDoOnce(void*)
     }
     if(!WSARecvMsg)
         cantProceed("Unable to get &WSARecvMsg!!");
+
+    evsocket::canIPv6 = evsocket::init_canIPv6();
 }
 
 void osiSockAttachExt()

--- a/src/os/default/osdSockExt.cpp
+++ b/src/os/default/osdSockExt.cpp
@@ -4,6 +4,11 @@
  * in file LICENSE that is included with this distribution.
  */
 
+#ifdef __APPLE__
+// expose IPV6_PKTINFO
+#  define __APPLE_USE_RFC_3542
+#endif
+
 #include "osiSockExt.h"
 
 #include <string.h>
@@ -19,6 +24,11 @@ extern "C" {
 }
 #endif
 
+// some *BSD (OSX but not RTEMS5/libbsd) use IPV6_PKTINFO to enable RX
+#if defined(IPV6_PKTINFO) && !defined(IPV6_RECVPKTINFO)
+#  define IPV6_RECVPKTINFO IPV6_PKTINFO
+#endif
+
 #include <pvxs/log.h>
 #include <evhelper.h>
 
@@ -29,7 +39,7 @@ DEFINE_LOGGER(logiface, "pvxs.iface");
 
 void osiSockAttachExt() {}
 
-void enable_SO_RXQ_OVFL(SOCKET sock)
+void evsocket::enable_SO_RXQ_OVFL() const
 {
 #ifdef SO_RXQ_OVFL
     // Linux specific feature exposes OS dropped packet count
@@ -40,34 +50,42 @@ void enable_SO_RXQ_OVFL(SOCKET sock)
 #endif
 }
 
-void enable_IP_PKTINFO(SOCKET sock)
+void evsocket::enable_IP_PKTINFO() const
 {
-    /* linux, some *BSD's (OSX), and winsock package both destination address (from ip header)
+    if(af==AF_INET) {
+
+        /* linux, some *BSD's (OSX), and winsock package both destination address (from ip header)
      * and receiving interface index (from host) into one IP_PKTINFO control message.
      * Remaining *BSD's can deliver these in separate IP_ORIGDSTADDR and IP_RECVIF messages.
      */
 #ifdef IP_PKTINFO
-    int val = 1;
-    if(setsockopt(sock, IPPROTO_IP, IP_PKTINFO, (char*)&val, sizeof(val)))
-        log_warn_printf(log, "Unable to set IP_PKTINFO: %d\n", SOCKERRNO);
+        int val = 1;
+        if(setsockopt(sock, IPPROTO_IP, IP_PKTINFO, (char*)&val, sizeof(val)))
+            log_warn_printf(log, "Unable to set IP_PKTINFO: %d\n", SOCKERRNO);
 
 #else
 #  ifdef IP_ORIGDSTADDR
-    {
-        int val = 1;
-        if(setsockopt(sock, IPPROTO_IP, IP_ORIGDSTADDR, (char*)&val, sizeof(val)))
-            log_warn_printf(log, "Unable to set IP_ORIGDSTADDR: %d\n", SOCKERRNO);
-    }
+        {
+            int val = 1;
+            if(setsockopt(sock, IPPROTO_IP, IP_ORIGDSTADDR, (char*)&val, sizeof(val)))
+                log_warn_printf(log, "Unable to set IP_ORIGDSTADDR: %d\n", SOCKERRNO);
+        }
 
 #  endif
 #  ifdef IP_RECVIF
-    {
-        int val = 1;
-        if(setsockopt(sock, IPPROTO_IP, IP_RECVIF, (char*)&val, sizeof(val)))
-            log_warn_printf(log, "Unable to set IP_RECVIF: %d\n", SOCKERRNO);
-    }
+        {
+            int val = 1;
+            if(setsockopt(sock, IPPROTO_IP, IP_RECVIF, (char*)&val, sizeof(val)))
+                log_warn_printf(log, "Unable to set IP_RECVIF: %d\n", SOCKERRNO);
+        }
 #  endif
 #endif
+
+    } else if(af==AF_INET6) {
+        int val = 1;
+        if(setsockopt(sock, IPPROTO_IPV6, IPV6_RECVPKTINFO, (char*)&val, sizeof(val)))
+            log_warn_printf(log, "Unable to set IPV6_PKTINFO reception: %d\n", SOCKERRNO);
+    }
 }
 
 int recvfromx::call()
@@ -81,10 +99,12 @@ int recvfromx::call()
     msg.msg_name = &(*src)->sa;
     msg.msg_namelen = src ? src->size() : 0u;
 
-    alignas (alignof (cmsghdr)) char cbuf[0u
+    alignas (cmsghdr) char cbuf[0u
 #ifdef SO_RXQ_OVFL
             + CMSG_SPACE(sizeof(ndrop))
 #endif
+            // only need space for IPv4 option(s) or IPv6 option, never both.
+            + impl::cmax(0
 #ifdef IP_PKTINFO
             + CMSG_SPACE(sizeof(in_pktinfo))
 #else
@@ -95,6 +115,9 @@ int recvfromx::call()
             + CMSG_SPACE(sizeof(sockaddr_dl))
 #  endif
 #endif
+                  ,0
+            + CMSG_SPACE(sizeof(in6_pktinfo))
+                  ) // cmax
             ];
     msg.msg_control = cbuf;
     msg.msg_controllen = sizeof(cbuf);
@@ -143,6 +166,16 @@ int recvfromx::call()
             }
 #  endif
 #endif
+            else if(hdr->cmsg_level==IPPROTO_IPV6 && hdr->cmsg_type==IPV6_PKTINFO && hdr->cmsg_len>=CMSG_LEN(sizeof(in6_pktinfo))) {
+                if(dst) {
+                    (*dst)->in6.sin6_family = AF_INET6;
+                    memcpy(&(*dst)->in6.sin6_addr, CMSG_DATA(hdr) + offsetof(in6_pktinfo, ipi6_addr), sizeof(in6_addr));
+                }
+
+                decltype(in6_pktinfo::ipi6_ifindex) idx;
+                memcpy(&idx, CMSG_DATA(hdr) + offsetof(in6_pktinfo, ipi6_ifindex), sizeof(idx));
+                dstif = idx;
+            }
         }
     }
 
@@ -151,20 +184,22 @@ int recvfromx::call()
 
 namespace impl {
 
-void IfaceMap::refresh() {
+decltype (IfaceMap::byIndex) IfaceMap::_refresh() {
     ifaddrs* addrs = nullptr;
 
-    decltype (info) temp;
+    decltype (byIndex) temp;
 
     if(getifaddrs(&addrs)) {
         log_warn_printf(logiface, "Unable to getifaddrs() errno=%d\n", errno);
-        return;
+        return temp;
     }
 
     try {
         for(const ifaddrs* ifa = addrs; ifa; ifa = ifa->ifa_next) {
-            if(ifa->ifa_addr->sa_family!=AF_INET) {
-                log_debug_printf(logiface, "Ignoring interface '%s' address !ipv4\n", ifa->ifa_name);
+            const auto af = ifa->ifa_addr->sa_family;
+            if((af!=AF_INET && af!=AF_INET6) || ifa->ifa_name[0]=='\0') {
+                log_debug_printf(logiface, "Ignoring interface '%s' address family=%d\n",
+                                 ifa->ifa_name, af);
                 continue;
             }
 
@@ -174,12 +209,28 @@ void IfaceMap::refresh() {
                 continue;
             }
 
-            //TODO: any flags to check?
+            if(!(ifa->ifa_flags&IFF_UP))
+                continue; // not configured, skip...
 
-            auto pair = temp[idx].emplace(ifa->ifa_addr, sizeof(sockaddr_in));
+            auto it = temp.find(idx);
+            if(it==temp.end()) {
+                // encountering new index
+                bool isLO = ifa->ifa_flags&IFF_LOOPBACK;
+                auto pair = temp.emplace(std::piecewise_construct,
+                                         std::forward_as_tuple(idx),
+                                         std::forward_as_tuple(ifa->ifa_name, idx, isLO));
+                assert(pair.second);
+                it = pair.first;
+            }
 
-            log_debug_printf(logiface, "Found interface %lld \"%s\" w/ %s\n",
-                             (long long)idx, ifa->ifa_name, pair.first->tostring().c_str());
+            // IFF_BROADCAST does not apply to IPv6
+            bool hasB = ifa->ifa_addr->sa_family==AF_INET && (ifa->ifa_flags&IFF_BROADCAST);
+
+            auto pair = it->second.addrs.emplace(SockAddr(ifa->ifa_addr),
+                                                 SockAddr(hasB ? ifa->ifa_broadaddr : nullptr));
+
+            log_debug_printf(logiface, "Found interface %lld \"%s\" w/ %d %s\n",
+                             (long long)idx, ifa->ifa_name, af, pair.first->first.tostring().c_str());
         }
 
     } catch(...){
@@ -188,7 +239,7 @@ void IfaceMap::refresh() {
     }
     freeifaddrs(addrs);
 
-    info.swap(temp);
+    return temp;
 }
 
 } // namespace impl

--- a/src/os/default/osdSockExt.cpp
+++ b/src/os/default/osdSockExt.cpp
@@ -149,7 +149,7 @@ int recvfromx::call()
 
     if(ret>=0) { // on success, check for control messages
         if(msg.msg_flags & MSG_CTRUNC)
-            log_warn_printf(log, "MSG_CTRUNC, expand buffer %zu <- %zu\n", msg.msg_controllen, sizeof(cbuf));
+            log_warn_printf(log, "MSG_CTRUNC, expand buffer %zu <- %zu\n", size_t(msg.msg_controllen), sizeof(cbuf));
 
         for(cmsghdr *hdr = CMSG_FIRSTHDR(&msg); hdr ; hdr = CMSG_NXTHDR(&msg, hdr)) {
             if(0) {}

--- a/src/os/default/osdSockExt.cpp
+++ b/src/os/default/osdSockExt.cpp
@@ -37,7 +37,19 @@ namespace pvxs {
 DEFINE_LOGGER(log, "pvxs.util");
 DEFINE_LOGGER(logiface, "pvxs.iface");
 
-void osiSockAttachExt() {}
+static
+epicsThreadOnceId oseOnce = EPICS_THREAD_ONCE_INIT;
+
+static
+void oseDoOnce(void*)
+{
+    evsocket::canIPv6 = evsocket::init_canIPv6();
+}
+
+void osiSockAttachExt() {
+    osiSockAttach();
+    epicsThreadOnce(&oseOnce, &oseDoOnce, nullptr);
+}
 
 void evsocket::enable_SO_RXQ_OVFL() const
 {

--- a/src/os/default/osdSockExt.cpp
+++ b/src/os/default/osdSockExt.cpp
@@ -1,0 +1,196 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * pvxs is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+
+#include "osiSockExt.h"
+
+#include <string.h>
+
+#include <sys/types.h>
+#include <net/if.h>
+#include <ifaddrs.h>
+
+#ifdef __rtems__
+// missing extern C circa RTEMS 5.1
+extern "C" {
+#  include <net/if_dl.h>
+}
+#endif
+
+#include <pvxs/log.h>
+#include <evhelper.h>
+
+namespace pvxs {
+
+DEFINE_LOGGER(log, "pvxs.util");
+DEFINE_LOGGER(logiface, "pvxs.iface");
+
+void osiSockAttachExt() {}
+
+void enable_SO_RXQ_OVFL(SOCKET sock)
+{
+#ifdef SO_RXQ_OVFL
+    // Linux specific feature exposes OS dropped packet count
+    int val = 1;
+    if(setsockopt(sock, SOL_SOCKET, SO_RXQ_OVFL, (char*)&val, sizeof(val)))
+        log_warn_printf(log, "Unable to set SO_RXQ_OVFL: %d\n", SOCKERRNO);
+
+#endif
+}
+
+void enable_IP_PKTINFO(SOCKET sock)
+{
+    /* linux, some *BSD's (OSX), and winsock package both destination address (from ip header)
+     * and receiving interface index (from host) into one IP_PKTINFO control message.
+     * Remaining *BSD's can deliver these in separate IP_ORIGDSTADDR and IP_RECVIF messages.
+     */
+#ifdef IP_PKTINFO
+    int val = 1;
+    if(setsockopt(sock, IPPROTO_IP, IP_PKTINFO, (char*)&val, sizeof(val)))
+        log_warn_printf(log, "Unable to set IP_PKTINFO: %d\n", SOCKERRNO);
+
+#else
+#  ifdef IP_ORIGDSTADDR
+    {
+        int val = 1;
+        if(setsockopt(sock, IPPROTO_IP, IP_ORIGDSTADDR, (char*)&val, sizeof(val)))
+            log_warn_printf(log, "Unable to set IP_ORIGDSTADDR: %d\n", SOCKERRNO);
+    }
+
+#  endif
+#  ifdef IP_RECVIF
+    {
+        int val = 1;
+        if(setsockopt(sock, IPPROTO_IP, IP_RECVIF, (char*)&val, sizeof(val)))
+            log_warn_printf(log, "Unable to set IP_RECVIF: %d\n", SOCKERRNO);
+    }
+#  endif
+#endif
+}
+
+int recvfromx::call()
+{
+    msghdr msg{};
+
+    iovec iov = {buf, buflen};
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1u;
+
+    msg.msg_name = &(*src)->sa;
+    msg.msg_namelen = src ? src->size() : 0u;
+
+    alignas (alignof (cmsghdr)) char cbuf[0u
+#ifdef SO_RXQ_OVFL
+            + CMSG_SPACE(sizeof(ndrop))
+#endif
+#ifdef IP_PKTINFO
+            + CMSG_SPACE(sizeof(in_pktinfo))
+#else
+#  if defined(IP_ORIGDSTADDR)
+            + CMSG_SPACE(sizeof(sockaddr_in))
+#  endif
+#  if defined(IP_RECVIF)
+            + CMSG_SPACE(sizeof(sockaddr_dl))
+#  endif
+#endif
+            ];
+    msg.msg_control = cbuf;
+    msg.msg_controllen = sizeof(cbuf);
+
+    if(dst)
+        *dst = SockAddr();
+    dstif = -1;
+    ndrop = 0u;
+
+    int ret = recvmsg(sock, &msg, 0);
+
+    if(ret>=0) { // on success, check for control messages
+        if(msg.msg_flags & MSG_CTRUNC)
+            log_warn_printf(log, "MSG_CTRUNC, expand buffer %zu <- %zu\n", msg.msg_controllen, sizeof(cbuf));
+
+        for(cmsghdr *hdr = CMSG_FIRSTHDR(&msg); hdr ; hdr = CMSG_NXTHDR(&msg, hdr)) {
+            if(0) {}
+#ifdef SO_RXQ_OVFL
+            else if(hdr->cmsg_level==SOL_SOCKET && hdr->cmsg_type==SO_RXQ_OVFL && hdr->cmsg_len>=CMSG_LEN(sizeof(ndrop))) {
+                memcpy(&ndrop, CMSG_DATA(hdr), sizeof(ndrop));
+            }
+#endif
+#ifdef IP_PKTINFO
+            else if(hdr->cmsg_level==IPPROTO_IP && hdr->cmsg_type==IP_PKTINFO && hdr->cmsg_len>=CMSG_LEN(sizeof(in_pktinfo))) {
+                if(dst) {
+                    (*dst)->in.sin_family = AF_INET;
+                    memcpy(&(*dst)->in.sin_addr, CMSG_DATA(hdr) + offsetof(in_pktinfo, ipi_addr), sizeof(in_addr_t));
+                }
+
+                decltype(in_pktinfo::ipi_ifindex) idx;
+                memcpy(&idx, CMSG_DATA(hdr) + offsetof(in_pktinfo, ipi_ifindex), sizeof(idx));
+                dstif = idx;
+            }
+
+#else
+#  ifdef IP_ORIGDSTADDR
+            else if(dst && hdr->cmsg_level==IPPROTO_IP && hdr->cmsg_type==IP_ORIGDSTADDR && hdr->cmsg_len>=CMSG_LEN(sizeof(sockaddr_in))) {
+                memcpy(&(*dst)->in, CMSG_DATA(hdr), sizeof(sockaddr_in));
+            }
+#  endif
+#  ifdef IP_RECVIF
+            else if(dst && hdr->cmsg_level==IPPROTO_IP && hdr->cmsg_type==IP_RECVIF && hdr->cmsg_len>=CMSG_LEN(sizeof(sockaddr_dl))) {
+                decltype (sockaddr_dl::sdl_index) idx;
+                memcpy(&idx, CMSG_DATA(hdr) + offsetof(sockaddr_dl, sdl_index), sizeof(idx));
+                dstif = idx;
+            }
+#  endif
+#endif
+        }
+    }
+
+    return ret;
+}
+
+namespace impl {
+
+void IfaceMap::refresh() {
+    ifaddrs* addrs = nullptr;
+
+    decltype (info) temp;
+
+    if(getifaddrs(&addrs)) {
+        log_warn_printf(logiface, "Unable to getifaddrs() errno=%d\n", errno);
+        return;
+    }
+
+    try {
+        for(const ifaddrs* ifa = addrs; ifa; ifa = ifa->ifa_next) {
+            if(ifa->ifa_addr->sa_family!=AF_INET) {
+                log_debug_printf(logiface, "Ignoring interface '%s' address !ipv4\n", ifa->ifa_name);
+                continue;
+            }
+
+            auto idx(if_nametoindex(ifa->ifa_name));
+            if(idx<=0) {
+                log_warn_printf(logiface, "Unable to find index of interface '%s'\n", ifa->ifa_name);
+                continue;
+            }
+
+            //TODO: any flags to check?
+
+            auto pair = temp[idx].emplace(ifa->ifa_addr, sizeof(sockaddr_in));
+
+            log_debug_printf(logiface, "Found interface %lld \"%s\" w/ %s\n",
+                             (long long)idx, ifa->ifa_name, pair.first->tostring().c_str());
+        }
+
+    } catch(...){
+        freeifaddrs(addrs);
+        throw;
+    }
+    freeifaddrs(addrs);
+
+    info.swap(temp);
+}
+
+} // namespace impl
+
+} // namespace pvxs

--- a/src/os/default/osdSockExt.cpp
+++ b/src/os/default/osdSockExt.cpp
@@ -44,6 +44,12 @@ static
 void oseDoOnce(void*)
 {
     evsocket::canIPv6 = evsocket::init_canIPv6();
+#ifdef __linux__
+    // TODO: detect WSL1 somehow.  (Is WSL2 really Linux IP stack?)
+    evsocket::ipstack = evsocket::Linsock;
+#else
+    evsocket::ipstack = evsocket::GenericBSD;
+#endif
 }
 
 void osiSockAttachExt() {

--- a/src/osiSockExt.h
+++ b/src/osiSockExt.h
@@ -1,0 +1,116 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * pvxs is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+
+#ifndef OSISOCKEXT_H
+#define OSISOCKEXT_H
+
+#include <osiSock.h>
+
+#include <string>
+
+#include <event2/util.h>
+
+#include <pvxs/version.h>
+
+namespace pvxs {
+
+PVXS_API
+void osiSockAttachExt();
+
+struct SockAttach {
+    SockAttach() { osiSockAttachExt(); }
+    ~SockAttach() { osiSockRelease(); }
+};
+
+//! representation of a network address
+struct PVXS_API SockAddr {
+    union store_t {
+        sockaddr sa;
+        sockaddr_in in;
+#ifdef AF_INET6
+        sockaddr_in6 in6;
+#endif
+    };
+private:
+    store_t  store;
+public:
+
+    explicit SockAddr(int af = AF_UNSPEC);
+    explicit SockAddr(int af, const char *address, unsigned short port=0);
+    explicit SockAddr(const sockaddr *addr, ev_socklen_t len);
+    inline explicit SockAddr(int af, const std::string& address) :SockAddr(af, address.c_str()) {}
+
+    size_t size() const;
+
+    inline unsigned short family() const { return store.sa.sa_family; }
+    unsigned short port() const;
+    void setPort(unsigned short port);
+    SockAddr withPort(unsigned short port) const {
+        SockAddr temp(*this);
+        temp.setPort(port);
+        return temp;
+    }
+
+    void setAddress(const char *, unsigned short port=0);
+
+    bool isAny() const;
+    bool isLO() const;
+
+    store_t* operator->() { return &store; }
+    const store_t* operator->() const { return &store; }
+
+    std::string tostring() const;
+
+    static SockAddr any(int af, unsigned port=0);
+    static SockAddr loopback(int af, unsigned port=0);
+
+    inline int compare(const SockAddr& o, bool useport=true) const {
+        return evutil_sockaddr_cmp(&store.sa, &o.store.sa, useport);
+    }
+
+    inline bool operator<(const SockAddr& o) const {
+        return evutil_sockaddr_cmp(&store.sa, &o.store.sa, true)<0;
+    }
+    inline bool operator==(const SockAddr& o) const {
+        return evutil_sockaddr_cmp(&store.sa, &o.store.sa, true)==0;
+    }
+    inline bool operator!=(const SockAddr& o) const {
+        return !(*this==o);
+    }
+};
+
+// compare address only, ignore port number
+struct SockAddrOnlyLess {
+    bool operator()(const SockAddr& lhs, const SockAddr& rhs) const {
+        return lhs.compare(rhs, false)<0;
+    }
+};
+
+PVXS_API
+std::ostream& operator<<(std::ostream& strm, const SockAddr& addr);
+
+// Linux specific include OS dropped packet counter as cmsg
+void enable_SO_RXQ_OVFL(SOCKET sock);
+// Include destination address as cmsg
+PVXS_API
+void enable_IP_PKTINFO(SOCKET sock);
+
+struct recvfromx {
+    evutil_socket_t sock;
+    void *buf;
+    size_t buflen;
+    SockAddr* src;
+    SockAddr* dst;  // if enable_IP_PKTINFO()
+    int64_t dstif;  // if enable_IP_PKTINFO(), destination interface index
+    uint32_t ndrop; // if enable_SO_RXQ_OVFL()
+
+    PVXS_API
+    int call();
+};
+
+} // namespace pvxs
+
+#endif // OSISOCKEXT_H

--- a/src/osiSockExt.h
+++ b/src/osiSockExt.h
@@ -44,6 +44,8 @@ public:
     inline explicit SockAddr(int af, const std::string& address) :SockAddr(af, address.c_str()) {}
 
     size_t size() const;
+    inline
+    size_t capacity() const { return sizeof(store); }
 
     inline unsigned short family() const { return store.sa.sa_family; }
     unsigned short port() const;
@@ -58,6 +60,7 @@ public:
 
     bool isAny() const;
     bool isLO() const;
+    bool isMCast() const;
 
     store_t* operator->() { return &store; }
     const store_t* operator->() const { return &store; }

--- a/src/pvaproto.h
+++ b/src/pvaproto.h
@@ -589,8 +589,13 @@ enum class pva_subcmd {
 };
 
 struct Header {
-    uint8_t cmd, flags;
-    uint32_t len;
+    uint8_t cmd=0u, flags=0u, version=0u;
+    uint32_t len=0u;
+    constexpr Header() {}
+    explicit
+    constexpr Header(uint8_t cmd, uint8_t flags, uint32_t len)
+        :cmd(cmd), flags(flags), version(0u), len(len)
+    {}
 };
 
 template<typename Buf>
@@ -622,6 +627,7 @@ void from_wire(Buf& buf, Header& H)
     } else {
         H.cmd = buf[3];
         H.flags = buf[2];
+        H.version = buf[1];
         // Set/change buffer endianness
         buf.be = H.flags&pva_flags::MSB;
         buf.skip(4u, __FILE__, __LINE__);

--- a/src/pvxs/client.h
+++ b/src/pvxs/client.h
@@ -940,10 +940,15 @@ public:
 DiscoverBuilder Context::discover(std::function<void (const Discovered &)> && fn) { return DiscoverBuilder(pvt, std::move(fn)); }
 
 struct PVXS_API Config {
-    //! List of unicast and broadcast addresses
+    /** List of unicast, multicast, and broadcast addresses to which search requests will be sent.
+     *
+     * Entries may take the forms:
+     * - <ipaddr>[:<port#>]
+     * - <ipmultiaddr>[:<port>][,<ttl>][@<ifaceaddr>]
+     */
     std::vector<std::string> addressList;
 
-    //! List of interface addresses on which beacons may be received.
+    //! List of local interface addresses on which beacons may be received.
     //! Also constrains autoAddrList to only consider broadcast addresses of listed interfaces.
     //! Empty implies wildcard 0.0.0.0
     std::vector<std::string> interfaces;

--- a/src/pvxs/server.h
+++ b/src/pvxs/server.h
@@ -180,7 +180,8 @@ struct PVXS_API Config {
 
     //! Configuration limited to the local loopback interface on a randomly chosen port.
     //! Suitable for use in self-contained unit-tests.
-    static Config isolated();
+    //! @since UNRELEASED Address family argument added.
+    static Config isolated(int family=AF_INET);
 
     //! update using defined EPICS_PVA* environment variables
     Config& applyEnv();

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -458,6 +458,8 @@ Server::Pvt::Pvt(const Config &conf)
 
         for(const auto& addr : effective.beaconDestinations) {
             beaconDest.emplace_back(addr.c_str(), effective.udp_port);
+            log_debug_printf(serversetup, "Will send beacons to %s\n",
+                             std::string(SB()<<beaconDest.back()).c_str());
         }
     });
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -375,8 +375,7 @@ std::ostream& operator<<(std::ostream& strm, const Server& serv)
 }
 
 Server::Pvt::Pvt(const Config &conf)
-    :canIPv6(evsocket::canIPv6())
-    ,effective(conf)
+    :effective(conf)
     ,beaconMsg(128)
     ,acceptor_loop("PVXTCP", epicsThreadPriorityCAServerLow-2)
     ,beaconSender4(AF_INET, SOCK_DGRAM, 0)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -433,6 +433,10 @@ Server::Pvt::Pvt(const Config &conf)
 #endif
     }
 
+    if(tcpifaces.empty()) {
+        log_err_printf(serversetup, "Server Unreachable.  Interface address list includes not TCP interfaces.%s", "\n");
+    }
+
     for(const auto& addr : effective.ignoreAddrs) {
         SockAddr temp(addr.c_str());
         ignoreList.push_back(temp);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -40,6 +40,11 @@ DEFINE_LOGGER(serversetup, "pvxs.server.setup");
 DEFINE_LOGGER(serverio, "pvxs.server.io");
 DEFINE_LOGGER(serversearch, "pvxs.server.search");
 
+// mimic pvAccessCPP server (almost)
+// send a "burst" of beacons, then fallback to a longer interval
+static constexpr timeval beaconIntervalShort{15, 0};
+static constexpr timeval beaconIntervalLong{180, 0};
+
 Server Server::fromEnv()
 {
     return Config::fromEnv().build();
@@ -722,9 +727,9 @@ void Server::Pvt::doBeacons(short evt)
 
     // mimic pvAccessCPP server (almost)
     // send a "burst" of beacons, then fallback to a longer interval
-    timeval interval{180, 0};
+    timeval interval(beaconIntervalLong);
     if(beaconCnt<10u) {
-        interval = {15, 0};
+        interval = beaconIntervalShort;
         beaconCnt++;
     }
     if(event_add(beaconTimer.get(), &interval))

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -416,8 +416,8 @@ Server::Pvt::Pvt(const Config &conf)
             listeners.push_back(manager.onSearch(any6, cb));
         }
 
-#ifndef _WIN32
-        if(addr.addr.family()==AF_INET && !addr.addr.isAny() && !addr.addr.isMCast()) {
+        if(evsocket::ipstack!=evsocket::Winsock
+                && addr.addr.family()==AF_INET && !addr.addr.isAny() && !addr.addr.isMCast()) {
             /* An oddness of BSD sockets (not winsock) is that binding to
              * INADDR_ANY will receive unicast and broadcast, but binding to
              * a specific interface address receives only unicast.  The trick
@@ -429,7 +429,6 @@ Server::Pvt::Pvt(const Config &conf)
                 listeners.push_back(manager.onSearch(bcast, cb));
             }
         }
-#endif
     }
 
     if(tcpifaces.empty()) {

--- a/src/serverconn.cpp
+++ b/src/serverconn.cpp
@@ -387,7 +387,7 @@ ServIface::ServIface(const SockAddr &addr, server::Server::Pvt *server, bool fal
     auto orig_port = bind_addr.port();
 
 #ifdef __linux__
-    if(server->canIPv6 && bind_addr.family()==AF_INET && bind_addr.isAny()) {
+    if(evsocket::canIPv6 && bind_addr.family()==AF_INET && bind_addr.isAny()) {
         // Linux IP stack disallows binding both 0.0.0.0 and [::] for the same port.
         // so promote to IPv6 when possible
         bind_addr = SockAddr::any(AF_INET6, bind_addr.port());

--- a/src/serverconn.cpp
+++ b/src/serverconn.cpp
@@ -386,11 +386,14 @@ ServIface::ServIface(const SockAddr &addr, server::Server::Pvt *server, bool fal
     server->acceptor_loop.assertInLoop();
     auto orig_port = bind_addr.port();
 
+#ifdef __linux__
     if(server->canIPv6 && bind_addr.family()==AF_INET && bind_addr.isAny()) {
-        // promote to IPv6 with IPv4 support
+        // Linux IP stack disallows binding both 0.0.0.0 and [::] for the same port.
+        // so promote to IPv6 when possible
         bind_addr = SockAddr::any(AF_INET6, bind_addr.port());
         log_debug_printf(connsetup, "Promote 0.0.0.0 -> [::]%s", "\n");
     }
+#endif
 
     sock = evsocket(bind_addr.family(), SOCK_STREAM, 0);
 

--- a/src/serverconn.cpp
+++ b/src/serverconn.cpp
@@ -403,12 +403,12 @@ ServIface::ServIface(const SockAddr &addr, server::Server::Pvt *server, bool fal
             sock.bind(bind_addr);
         } catch(std::system_error& e) {
             if(fallback && e.code().value()==SOCK_EADDRINUSE) {
-                log_debug_printf(connsetup, "Address %s in use", bind_addr.tostring().c_str());
+                log_debug_printf(connsetup, "Address %s in use\n", bind_addr.tostring().c_str());
                 bind_addr.setPort(0);
                 fallback = false;
                 continue;
             }
-            log_err_printf(connsetup, "Bind to %s fails", bind_addr.tostring().c_str());
+            log_err_printf(connsetup, "Bind to %s fails\n", bind_addr.tostring().c_str());
             throw;
         }
         break;

--- a/src/serverconn.cpp
+++ b/src/serverconn.cpp
@@ -386,15 +386,6 @@ ServIface::ServIface(const SockAddr &addr, server::Server::Pvt *server, bool fal
     server->acceptor_loop.assertInLoop();
     auto orig_port = bind_addr.port();
 
-#ifdef __linux__
-    if(evsocket::canIPv6 && bind_addr.family()==AF_INET && bind_addr.isAny()) {
-        // Linux IP stack disallows binding both 0.0.0.0 and [::] for the same port.
-        // so promote to IPv6 when possible
-        bind_addr = SockAddr::any(AF_INET6, bind_addr.port());
-        log_debug_printf(connsetup, "Promote 0.0.0.0 -> [::]%s", "\n");
-    }
-#endif
-
     sock = evsocket(bind_addr.family(), SOCK_STREAM, 0);
 
     if(evutil_make_listen_socket_reuseable(sock.sock))

--- a/src/serverconn.h
+++ b/src/serverconn.h
@@ -200,7 +200,6 @@ using namespace impl;
 struct Server::Pvt
 {
     SockAttach attach;
-    const bool canIPv6;
 
     std::weak_ptr<Server::Pvt> internal_self;
 

--- a/src/serverconn.h
+++ b/src/serverconn.h
@@ -169,7 +169,7 @@ struct ServIface
     evsocket sock;
     evlisten listener;
 
-    ServIface(const std::string& addr, unsigned short port, server::Server::Pvt *server, bool fallback);
+    ServIface(const SockAddr &addr, server::Server::Pvt *server, bool fallback);
 
     static void onConnS(struct evconnlistener *listener, evutil_socket_t sock, struct sockaddr *peer, int socklen, void *raw);
 };
@@ -200,6 +200,7 @@ using namespace impl;
 struct Server::Pvt
 {
     SockAttach attach;
+    const bool canIPv6;
 
     std::weak_ptr<Server::Pvt> internal_self;
 
@@ -218,13 +219,13 @@ struct Server::Pvt
     evbase acceptor_loop;
 
     std::list<std::unique_ptr<UDPListener> > listeners;
-    std::vector<SockAddr> beaconDest;
+    std::vector<SockEndpoint> beaconDest;
     std::vector<SockAddr> ignoreList;
 
     std::list<ServIface> interfaces;
     std::map<ServerConn*, std::shared_ptr<ServerConn> > connections;
 
-    evsocket beaconSender;
+    evsocket beaconSender4, beaconSender6;
     evevent beaconTimer;
 
     std::vector<uint8_t> searchReply;

--- a/src/udp_collector.cpp
+++ b/src/udp_collector.cpp
@@ -36,6 +36,7 @@ struct UDPCollector : public UDPManager::Search,
 {
     UDPManager::Pvt* const manager;
     SockAddr bind_addr;
+    SockAddr mcast_addr;
     std::string name;
     evsocket sock;
     evevent rx;
@@ -47,12 +48,19 @@ struct UDPCollector : public UDPManager::Search,
 
     std::set<UDPListener*> listeners;
 
+    // loopback collector for our port.
+    std::shared_ptr<UDPCollector> loSibling;
+    // for the loSibling, list of non-lo siblings for forwards
+    std::set<UDPCollector*> otherSiblings;
+
     UDPCollector(UDPManager::Pvt* manager, const SockAddr& bind_addr);
     ~UDPCollector();
 
     bool handle_one()
     {
         SockAddr dest;
+
+        buf.resize(0x10001);
 
         // For Search messages, we use PV name strings in-place by adding nils.
         // Ensure one extra byte at the end of the buffer for a nil after the last PV name
@@ -74,48 +82,38 @@ struct UDPCollector : public UDPManager::Search,
             }
             return false; // wait for more I/O
 
-        } else if(nrx<8) {
-            // maybe a zero (body) length packet?
-            // maybe an OS error?
-
-            log_info_printf(logio, "UDP ignore runt on %s\n", name.c_str());
-            return true;
-
-        } else if(buf[0]!=0xca || buf[1]==0 || (buf[2]&(pva_flags::Control|pva_flags::SegMask))) {
-            // minimum header size is 8 bytes
-            // ID byte must by 0xCA (because PVA has some paternal envy)
-            // ignore incompatible version 0
-            // UDP packets can't contain control messages, or use segmentation
-
-            log_info_printf(logio, "UDP ignore header%u %02x%02x%02x%02x on %s\n",
-                       unsigned(nrx), buf[0], buf[1], buf[2], buf[3],
-                    name.c_str());
-            return true;
         }
 
-        log_hex_printf(logio, Level::Debug, &buf[0], nrx, "UDP Rx %d, %s -> %s\n",
-                nrx, src.tostring().c_str(), dest.tostring().c_str());
+        log_hex_printf(logio, Level::Debug, &buf[0], nrx, "UDP %d Rx %d, %s -> %s (%s)\n",
+                sock.sock, nrx, src.tostring().c_str(), dest.tostring().c_str(), bind_addr.tostring().c_str());
+
+        process_one(dest, &buf[0], nrx, false);
+        return true;
+    }
+
+    void process_one(const SockAddr& dest, const uint8_t* buf, int nrx, bool originated)
+    {
+        FixedBuf M(true, const_cast<uint8_t*>(buf), nrx);
+        Header head{};
+        from_wire(M, head); // overwrites M.be
+
+        if(!M.good() || (head.flags&(pva_flags::Control|pva_flags::SegMask))) {
+            // UDP packets can't contain control messages, or use segmentation
+
+            log_hex_printf(logio, Level::Debug, &buf[0], nrx, "Ignore UDP message from %s\n", src.tostring().c_str());
+            return;
+        }
 
         names.clear();
 
-        bool be = buf[2]&pva_flags::MSB;
-
-        FixedBuf M(be, buf.data(), nrx);
-
-        uint8_t cmd = M[3];
-
-        M.skip(4, __FILE__, __LINE__);
-        uint32_t len=0;
-        from_wire(M, len);
-
-        if(len > M.size() && M.good()) {
+        if(head.len > M.size() && M.good()) {
             log_info_printf(logio, "UDP ignore header%u %02x%02x%02x%02x on %s\n",
                        unsigned(M.size()), M[0], M[1], M[2], M[3],
                     name.c_str());
-            return true;
+            return;
         }
 
-        switch(cmd) {
+        switch(head.cmd) {
 
         case CMD_SEARCH: {
             uint8_t flags = 0;
@@ -123,16 +121,36 @@ struct UDPCollector : public UDPManager::Search,
             uint16_t port = 0;
 
             from_wire(M, searchID);
+            auto save_flags = M.save();
             from_wire(M, flags);
             mustReply = flags&pva_search_flags::MustReply;
+
             M.skip(3, __FILE__, __LINE__); // unused/reserved
 
+            auto save_replyAddr = M.save();
             from_wire(M, replyAddr);
             from_wire(M, port);
             if(replyAddr.isAny()) {
                 replyAddr = src;
+                if(originated) {
+                    log_err_printf(logio, "CMD_ORIGIN_TAG search with reply to sender never works%s", "\n");
+                    return;
+                }
             }
             replyAddr.setPort(port);
+
+            if(M.good() && !originated && (flags&pva_search_flags::Unicast) && loSibling && dest.family()!=AF_UNSPEC) {
+                // clear unicast flag in forwarded message
+                *save_flags &= ~pva_search_flags::Unicast;
+                // recipient of forwarded message must use, and trust, replyAddr in body :(
+                {
+                    FixedBuf R(M.be, save_replyAddr, 16u);
+                    to_wire(R, replyAddr);
+                    assert(R.good());
+                }
+                loSibling->forwardM(dest, &buf[0], nrx);
+                return;
+            }
 
             // so far, only "tcp" transport has ever been seen.
             // however, we will consider and ignore any others which might appear
@@ -170,6 +188,9 @@ struct UDPCollector : public UDPManager::Search,
                 }
                 M.skip(chlen.size, __FILE__, __LINE__);
             }
+
+            // used by our reply()
+            src = replyAddr;
 
             if(M.good()) {
                 // ensure nil for final PV name
@@ -209,11 +230,41 @@ struct UDPCollector : public UDPManager::Search,
                     }
                 }
             }
-        }
             break;
         }
 
-        return true;
+        case CMD_ORIGIN_TAG: {
+            SockAddr origin; // aka. original destination
+            from_wire(M, origin);
+            M.skip(head.len-16u, __FILE__, __LINE__);
+
+            // only allow one CMD_ORIGIN_TAG message per packet
+            // only accept when sent to the mcast address from the loopback address
+            //   since we only join the mcast group on loopback this will hopefully
+            //   frustrate attempts to inject CMD_ORIGIN_TAG externally.
+            if(M.good() && !originated && dest.compare(mcast_addr,false)==0 && src.isLO()) {
+                origin.setPort(bind_addr.port());
+
+                originated = true;
+                log_debug_printf(logio, "Accept as originated from %s\n", origin.tostring().c_str());
+                for(auto sib : otherSiblings) {
+                    sib->process_one(origin, M.save(), M.size(), true);
+                }
+                return;
+            }
+            log_debug_printf(logio, "Ignore originated from %s %c%c%c%c\n",
+                             origin.tostring().c_str(),
+                             M.good() ? 'T' : 'F',
+                             !originated ? 'T' : 'F',
+                             dest.compare(mcast_addr,false)==0 ? 'T' : 'F',
+                             src.isLO() ? 'T' : 'F');
+
+            break;
+        }
+
+        default:
+            break; // ignore unknown
+        }
     }
     void handle(short ev)
     {
@@ -233,6 +284,8 @@ struct UDPCollector : public UDPManager::Search,
             log_crit_printf(logio, "Ignoring unhandled exception in UDPManager::handle(): %s\n", e.what());
         }
     }
+
+    void forwardM(const SockAddr& origin, const uint8_t* buf, size_t len);
 
     // Search interface
 public:
@@ -255,14 +308,35 @@ struct UDPManager::Pvt {
         // we should only be destroyed after that last collector has removed itself
         assert(collectors.empty());
     }
+
+    std::shared_ptr<UDPCollector> collect(const SockAddr& dest)
+    {
+        std::shared_ptr<UDPCollector> collector;
+
+        if(dest.port()!=0) {
+            auto it = collectors.find(dest);
+            if(it!=collectors.end()) {
+                try {
+                    collector = it->second->shared_from_this();
+                }catch(std::bad_weak_ptr&){
+                    // nothing to do
+                }
+            }
+        }
+
+        if(!collector) {
+            collector.reset(new UDPCollector(this, dest));
+        }
+        return collector;
+    }
 };
 
-UDPCollector::UDPCollector(UDPManager::Pvt *manager, const SockAddr& bind_addr)
+UDPCollector::UDPCollector(UDPManager::Pvt *manager, const SockAddr& requested_bind_addr)
     :manager(manager)
-    ,bind_addr(bind_addr)
-    ,sock(bind_addr.family(), SOCK_DGRAM, 0)
+    ,bind_addr(requested_bind_addr)
+    ,mcast_addr(AF_INET, "224.0.0.128")
+    ,sock(requested_bind_addr.family(), SOCK_DGRAM, 0)
     ,rx(event_new(manager->loop.base, sock.sock, EV_READ|EV_PERSIST, &handle_static, this))
-    ,buf(0x10001)
     ,beaconMsg(src)
 {
     manager->loop.assertInLoop();
@@ -270,22 +344,61 @@ UDPCollector::UDPCollector(UDPManager::Pvt *manager, const SockAddr& bind_addr)
     epicsSocketEnableAddressUseForDatagramFanout(sock.sock);
     enable_SO_RXQ_OVFL(sock.sock);
     enable_IP_PKTINFO(sock.sock);
-    sock.bind(this->bind_addr);
-    name = "UDP "+this->bind_addr.tostring();
+    sock.bind(bind_addr);
+    name = "UDP "+bind_addr.tostring();
 
-    log_info_printf(logsetup, "Bound to %s\n", name.c_str());
+    auto lo_addr(SockAddr::loopback(bind_addr.family(), bind_addr.port()));
+    assert(lo_addr.port()!=0u);
+    mcast_addr.setPort(bind_addr.port());
+
+    /* Bind this address to receive multicast over loopback, and also to send them.
+     * Notes:
+     * - Linux, it would be possible to bind to the mcast address in order to receive only
+     *   packets so destined.  It would also be possible to send mcasts from a socket
+     *   so bound.
+     * - OSX, it would be possible to bind to the mcast address, but not to send mcasts.
+     * - Winsock, it is not possible to bind to the mcast address.
+     *
+     * So we take the least common denominator across all platforms, which is to bind to the wildcard.
+     * This socket may then receive unicasts which need to be forwarded.
+     * Also broadcasts, which will be ignored (if no listeners).
+     */
+    auto mcast_bind_addr(SockAddr::any(AF_INET, bind_addr.port()));
+
+    if(bind_addr!=mcast_bind_addr) {
+        loSibling = manager->collect(mcast_bind_addr);
+        assert(this!=loSibling.get());
+
+        log_info_printf(logsetup, "Bound %d to %s with sibling %s\n", sock.sock, name.c_str(), loSibling->name.c_str());
+
+    } else {
+        // join group to receive
+        sock.mcast_join(mcast_addr, lo_addr);
+        // setup for re-transmit
+        sock.mcast_ttl(1); // make default explicit
+        sock.mcast_loop(true);
+        sock.mcast_iface(lo_addr);
+
+        log_info_printf(logsetup, "Bound %d to %s as lo\n", sock.sock, name.c_str());
+    }
 
     if(event_add(rx.get(), nullptr))
         throw std::runtime_error("Unable to create collector Rx event");
 
-    manager->collectors[this->bind_addr] = this;
+    if(loSibling)
+        loSibling->otherSiblings.insert(this);
+
+    manager->collectors[bind_addr] = this;
 }
 
 UDPCollector::~UDPCollector()
 {
     manager->loop.assertInLoop();
 
-    manager->collectors.erase(this->bind_addr);
+    if(loSibling)
+        loSibling->otherSiblings.erase(this);
+
+    manager->collectors.erase(bind_addr);
 
     // we should only be destroyed after that last listener has removed itself
     assert(listeners.empty());
@@ -390,21 +503,8 @@ UDPListener::UDPListener(const std::shared_ptr<UDPManager::Pvt> &manager, SockAd
 {
     manager->loop.assertInLoop();
 
-    if(dest.port()!=0) {
-        auto it = manager->collectors.find(dest);
-        if(it!=manager->collectors.end()) {
-            try {
-                collector = it->second->shared_from_this();
-            }catch(std::bad_weak_ptr&){
-                // nothing to do
-            }
-        }
-    }
-
-    if(!collector) {
-        collector.reset(new UDPCollector(manager.get(), dest));
-        dest = collector->bind_addr;
-    }
+    collector = manager->collect(dest);
+    dest = collector->bind_addr;
 }
 
 UDPListener::~UDPListener()
@@ -433,9 +533,31 @@ void UDPListener::start(bool s)
     });
 }
 
+void UDPCollector::forwardM(const SockAddr& origin, const uint8_t* obuf, size_t olen)
+{
+    log_debug_printf(logio, "Forward as originated for %s\n",
+                     origin.tostring().c_str());
+
+    buf.resize(8+16+olen);
+    {
+        FixedBuf M(true, &buf[0], buf.size());
+
+        to_wire(M, Header{CMD_ORIGIN_TAG, 0, 16u});
+        to_wire(M, origin);
+        assert(M.good());
+        memcpy(M.save(), obuf, olen);
+    }
+
+    src = mcast_addr;
+    reply(&buf[0], buf.size());
+}
+
 bool UDPCollector::reply(const void *msg, size_t msglen) const
 {
     manager->loop.assertInLoop();
+
+    log_hex_printf(logio, Level::Debug, msg, msglen, "Send %s -> %s\n",
+                   bind_addr.tostring().c_str(), src.tostring().c_str());
 
     int ntx = sendto(sock.sock, (char*)msg, msglen, 0, &src->sa, src.size());
     if(ntx<0) {
@@ -443,8 +565,9 @@ bool UDPCollector::reply(const void *msg, size_t msglen) const
         if(err==SOCK_EWOULDBLOCK || err==EAGAIN || err==SOCK_EINTR) {
             // nothing to do here
         } else {
-            log_warn_printf(logio, "UDP TX Error on %s : %s\n", name.c_str(),
-                       evutil_socket_error_to_string(err));
+            log_warn_printf(logio, "UDP TX Error on %s -> %s : (%d) %s\n",
+                            name.c_str(), src.tostring().c_str(),
+                            err, evutil_socket_error_to_string(err));
         }
         return false; // wait for more I/O
     }

--- a/src/udp_collector.cpp
+++ b/src/udp_collector.cpp
@@ -491,17 +491,13 @@ epicsThreadOnceId collector_once = EPICS_THREAD_ONCE_INIT;
 void collector_init(void *unused)
 {
     (void)unused;
-    try {
-        udp_gbl = new udp_gbl_t;
-    }catch(std::exception& e){
-        log_exc_printf(logsetup, "Unable to alloc udp_gbl: %s\n", e.what());
-    }
+    udp_gbl = new udp_gbl_t;
 }
 } // namespace
 
 UDPManager UDPManager::instance()
 {
-    epicsThreadOnce(&collector_once, &collector_init, nullptr);
+    threadOnce(&collector_once, &collector_init, nullptr);
     assert(udp_gbl);
 
     Guard G(udp_gbl->lock);

--- a/src/udp_collector.cpp
+++ b/src/udp_collector.cpp
@@ -457,7 +457,7 @@ bool UDPCollector::reply(const void *msg, size_t msglen) const
     log_hex_printf(logio, Level::Debug, msg, msglen, "Send %s -> %s\n",
                    bind_addr.tostring().c_str(), src.tostring().c_str());
 
-    int ntx = sendto(sock.sock, (char*)msg, msglen, 0, &src->sa, src.size());
+    auto ntx = sendto(sock.sock, (char*)msg, msglen, 0, &src->sa, src.size());
     if(ntx<0) {
         int err = evutil_socket_geterror(sock.sock);
         if(err==SOCK_EWOULDBLOCK || err==EAGAIN || err==SOCK_EINTR) {

--- a/src/udp_collector.cpp
+++ b/src/udp_collector.cpp
@@ -35,8 +35,10 @@ struct UDPCollector : public UDPManager::Search,
                       public std::enable_shared_from_this<UDPCollector>
 {
     UDPManager::Pvt* const manager;
-    SockAddr bind_addr;
-    SockAddr mcast_addr;
+    SockAddr bind_addr; // address our socket is bound to
+    SockAddr lo_mcast_addr; // destination endpoint for local mcast forwarding
+    SockAddr lo_addr;
+    std::set<std::pair<SockAddr, SockAddr>> mcast_grps; // mcast group+iface pairs which our socket has joined
     std::string name;
     evsocket sock;
     evevent rx;
@@ -48,238 +50,33 @@ struct UDPCollector : public UDPManager::Search,
 
     std::set<UDPListener*> listeners;
 
-    // loopback collector for our port.
-    std::shared_ptr<UDPCollector> loSibling;
-    // for the loSibling, list of non-lo siblings for forwards
-    std::set<UDPCollector*> otherSiblings;
-
-    UDPCollector(UDPManager::Pvt* manager, const SockAddr& bind_addr);
+    UDPCollector(UDPManager::Pvt* manager, uint16_t port);
     ~UDPCollector();
 
-    bool handle_one()
-    {
-        SockAddr dest;
+    void addListener(UDPListener *l);
+    void delListener(UDPListener *l);
 
-        buf.resize(0x10001);
+    bool handle_one();
 
-        // For Search messages, we use PV name strings in-place by adding nils.
-        // Ensure one extra byte at the end of the buffer for a nil after the last PV name
-        recvfromx rx{sock.sock, (char*)&buf[0], buf.size()-1, &src, &dest};
-        const int nrx = rx.call();
+    enum origin_t {
+        Remote,    // received from interface other than loopback
+        Loopback,  // received through loopback
+        OriginTag, // payload of CMD_ORIGIN_TAG
+    };
 
-        if(nrx>=0 && rx.ndrop!=0u && prevndrop!=rx.ndrop) {
-            log_debug_printf(logio, "UDP collector socket buffer overflowed %u -> %u\n", unsigned(prevndrop), unsigned(rx.ndrop));
-            prevndrop = rx.ndrop;
-        }
-
-        if(nrx<0) {
-            int err = evutil_socket_geterror(sock.sock);
-            if(err==SOCK_EWOULDBLOCK || err==EAGAIN || err==SOCK_EINTR) {
-                // nothing to do here
-            } else {
-                log_warn_printf(logio, "UDP RX Error on %s : %s\n", name.c_str(),
-                           evutil_socket_error_to_string(err));
-            }
-            return false; // wait for more I/O
-
-        }
-
-        log_hex_printf(logio, Level::Debug, &buf[0], nrx, "UDP %d Rx %d, %s -> %s (%s)\n",
-                sock.sock, nrx, src.tostring().c_str(), dest.tostring().c_str(), bind_addr.tostring().c_str());
-
-        process_one(dest, &buf[0], nrx, false);
-        return true;
-    }
-
-    void process_one(const SockAddr& dest, const uint8_t* buf, int nrx, bool originated)
-    {
-        FixedBuf M(true, const_cast<uint8_t*>(buf), nrx);
-        Header head{};
-        from_wire(M, head); // overwrites M.be
-
-        if(!M.good() || (head.flags&(pva_flags::Control|pva_flags::SegMask))) {
-            // UDP packets can't contain control messages, or use segmentation
-
-            log_hex_printf(logio, Level::Debug, &buf[0], nrx, "Ignore UDP message from %s\n", src.tostring().c_str());
-            return;
-        }
-
-        names.clear();
-
-        if(head.len > M.size() && M.good()) {
-            log_info_printf(logio, "UDP ignore header%u %02x%02x%02x%02x on %s\n",
-                       unsigned(M.size()), M[0], M[1], M[2], M[3],
-                    name.c_str());
-            return;
-        }
-
-        switch(head.cmd) {
-
-        case CMD_SEARCH: {
-            uint8_t flags = 0;
-            SockAddr replyAddr;
-            uint16_t port = 0;
-
-            from_wire(M, searchID);
-            auto save_flags = M.save();
-            from_wire(M, flags);
-            mustReply = flags&pva_search_flags::MustReply;
-
-            M.skip(3, __FILE__, __LINE__); // unused/reserved
-
-            auto save_replyAddr = M.save();
-            from_wire(M, replyAddr);
-            from_wire(M, port);
-            if(replyAddr.isAny()) {
-                replyAddr = src;
-                if(originated) {
-                    log_err_printf(logio, "CMD_ORIGIN_TAG search with reply to sender never works%s", "\n");
-                    return;
-                }
-            }
-            replyAddr.setPort(port);
-
-            if(M.good() && !originated && (flags&pva_search_flags::Unicast) && loSibling && dest.family()!=AF_UNSPEC) {
-                // clear unicast flag in forwarded message
-                *save_flags &= ~pva_search_flags::Unicast;
-                // recipient of forwarded message must use, and trust, replyAddr in body :(
-                {
-                    FixedBuf R(M.be, save_replyAddr, 16u);
-                    to_wire(R, replyAddr);
-                    assert(R.good());
-                }
-                loSibling->forwardM(dest, &buf[0], nrx);
-                return;
-            }
-
-            // so far, only "tcp" transport has ever been seen.
-            // however, we will consider and ignore any others which might appear
-            bool foundtcp = false;
-            Size nproto{0};
-            from_wire(M, nproto);
-            for(size_t i=0; i<nproto.size && M.good(); i++) {
-                Size nchar{0};
-                from_wire(M, nchar);
-
-                // shortcut to avoid allocating a std::string
-                // "tcp" is the only value we expect to see
-                foundtcp |= M.size()>=3 && nchar.size==3 && M[0]=='t' && M[1]=='c' && M[2]=='p';
-                M.skip(nchar.size, __FILE__, __LINE__);
-            }
-
-            // one Search message can include many PV names.
-            uint16_t nchan=0;
-            from_wire(M, nchan);
-
-            names.clear();
-            names.reserve(nchan);
-
-            for(size_t i=0; i<nchan && M.good(); i++) {
-                uint32_t id=0xffffffff; // poison
-                Size chlen{0};
-
-                auto mundge = M.save();
-                from_wire(M, id);
-                from_wire(M, chlen);
-                // inject nil for previous PV name
-                *mundge = '\0';
-                if(foundtcp && chlen.size<=M.size() && M.good()) {
-                    names.push_back(UDPManager::Search::Name{reinterpret_cast<const char*>(M.save()), id});
-                }
-                M.skip(chlen.size, __FILE__, __LINE__);
-            }
-
-            // used by our reply()
-            src = replyAddr;
-
-            if(M.good()) {
-                // ensure nil for final PV name
-                *M.save() = '\0';
-
-                for(auto L : listeners) {
-                    if(L->searchCB) {
-                        (L->searchCB)(*this);
-                    }
-                }
-            }
-
-            break;
-        }
-
-        case CMD_BEACON: {
-            uint16_t port = 0;
-
-            _from_wire<12>(M, &beaconMsg.guid[0], false, __FILE__, __LINE__);
-            M.skip(4, __FILE__, __LINE__); // skip flags, seq, and change count.  unused
-            from_wire(M, beaconMsg.server);
-            from_wire(M, port);
-            if(beaconMsg.server.isAny()) {
-                beaconMsg.server = src;
-            }
-            beaconMsg.server.setPort(port);
-
-            std::string proto;
-            from_wire(M, proto);
-
-            // ignore remaining "server status" blob
-
-            if(M.good() && proto=="tcp") {
-                for(auto L : listeners) {
-                    if(L->beaconCB) {
-                        (L->beaconCB)(beaconMsg);
-                    }
-                }
-            }
-            break;
-        }
-
-        case CMD_ORIGIN_TAG: {
-            SockAddr origin; // aka. original destination
-            from_wire(M, origin);
-            M.skip(head.len-16u, __FILE__, __LINE__);
-
-            // only allow one CMD_ORIGIN_TAG message per packet
-            // only accept when sent to the mcast address from the loopback address
-            //   since we only join the mcast group on loopback this will hopefully
-            //   frustrate attempts to inject CMD_ORIGIN_TAG externally.
-            if(M.good() && !originated && dest.compare(mcast_addr,false)==0 && src.isLO()) {
-                origin.setPort(bind_addr.port());
-
-                originated = true;
-                log_debug_printf(logio, "Accept as originated from %s\n", origin.tostring().c_str());
-                for(auto sib : otherSiblings) {
-                    sib->process_one(origin, M.save(), M.size(), true);
-                }
-                return;
-            }
-            log_debug_printf(logio, "Ignore originated from %s %c%c%c%c\n",
-                             origin.tostring().c_str(),
-                             M.good() ? 'T' : 'F',
-                             !originated ? 'T' : 'F',
-                             dest.compare(mcast_addr,false)==0 ? 'T' : 'F',
-                             src.isLO() ? 'T' : 'F');
-
-            break;
-        }
-
-        default:
-            break; // ignore unknown
-        }
-    }
-    void handle(short ev)
-    {
-        log_debug_printf(logio, "UDP %p event %x\n", rx.get(), ev);
-        if(!(ev&EV_READ))
-            return;
-
-        // handle up to 4 packets before going back to the reactor
-        for(unsigned i=0; i<4 && handle_one(); i++) {}
-    }
+    void process_one(const SockAddr& dest, const uint8_t* buf, size_t nrx, origin_t origin);
     static void handle_static(evutil_socket_t fd, short ev, void *raw)
     {
         (void)fd;
+        auto self = static_cast<UDPCollector*>(raw);
         try {
-            static_cast<UDPCollector*>(raw)->handle(ev);
+            log_debug_printf(logio, "UDP %p event %x\n", self->rx.get(), ev);
+            if(!(ev&EV_READ))
+                return;
+
+            // handle up to 4 packets before going back to the reactor
+            for(unsigned i=0; i<4 && self->handle_one(); i++) {}
+
         }catch(std::exception& e) {
             log_crit_printf(logio, "Ignoring unhandled exception in UDPManager::handle(): %s\n", e.what());
         }
@@ -296,9 +93,10 @@ public:
 struct UDPManager::Pvt {
 
     evbase loop;
+    IfaceMap ifmap;
 
     // only manipulate from loop worker thread
-    std::map<SockAddr, UDPCollector*> collectors;
+    std::map<uint16_t, UDPCollector*> collectors;
 
     Pvt()
         :loop("PVXUDP", epicsThreadPriorityCAServerLow-4)
@@ -314,7 +112,7 @@ struct UDPManager::Pvt {
         std::shared_ptr<UDPCollector> collector;
 
         if(dest.port()!=0) {
-            auto it = collectors.find(dest);
+            auto it = collectors.find(dest.port());
             if(it!=collectors.end()) {
                 try {
                     collector = it->second->shared_from_this();
@@ -325,17 +123,18 @@ struct UDPManager::Pvt {
         }
 
         if(!collector) {
-            collector.reset(new UDPCollector(this, dest));
+            collector.reset(new UDPCollector(this, dest.port()));
         }
         return collector;
     }
 };
 
-UDPCollector::UDPCollector(UDPManager::Pvt *manager, const SockAddr& requested_bind_addr)
+UDPCollector::UDPCollector(UDPManager::Pvt *manager, uint16_t requested_port)
     :manager(manager)
-    ,bind_addr(requested_bind_addr)
-    ,mcast_addr(AF_INET, "224.0.0.128")
-    ,sock(requested_bind_addr.family(), SOCK_DGRAM, 0)
+    ,bind_addr(SockAddr::any(AF_INET, requested_port))
+    ,lo_mcast_addr(bind_addr.family(), "224.0.0.128")
+    ,lo_addr(SockAddr::loopback(bind_addr.family()))
+    ,sock(bind_addr.family(), SOCK_DGRAM, 0)
     ,rx(event_new(manager->loop.base, sock.sock, EV_READ|EV_PERSIST, &handle_static, this))
     ,beaconMsg(src)
 {
@@ -344,14 +143,8 @@ UDPCollector::UDPCollector(UDPManager::Pvt *manager, const SockAddr& requested_b
     epicsSocketEnableAddressUseForDatagramFanout(sock.sock);
     enable_SO_RXQ_OVFL(sock.sock);
     enable_IP_PKTINFO(sock.sock);
-    sock.bind(bind_addr);
-    name = "UDP "+bind_addr.tostring();
 
-    auto lo_addr(SockAddr::loopback(bind_addr.family(), bind_addr.port()));
-    assert(lo_addr.port()!=0u);
-    mcast_addr.setPort(bind_addr.port());
-
-    /* Bind this address to receive multicast over loopback, and also to send them.
+    /* Always bind to wildcard to receive all uni/broad/multicast, and also to send them.
      * Notes:
      * - Linux, it would be possible to bind to the mcast address in order to receive only
      *   packets so destined.  It would also be possible to send mcasts from a socket
@@ -361,48 +154,322 @@ UDPCollector::UDPCollector(UDPManager::Pvt *manager, const SockAddr& requested_b
      *
      * So we take the least common denominator across all platforms, which is to bind to the wildcard.
      * This socket may then receive unicasts which need to be forwarded.
-     * Also broadcasts, which will be ignored (if no listeners).
      */
-    auto mcast_bind_addr(SockAddr::any(AF_INET, bind_addr.port()));
+    sock.bind(bind_addr);
+    name = "UDP "+bind_addr.tostring();
 
-    if(bind_addr!=mcast_bind_addr) {
-        loSibling = manager->collect(mcast_bind_addr);
-        assert(this!=loSibling.get());
+    lo_mcast_addr.setPort(bind_addr.port());
+    lo_addr.setPort(bind_addr.port());
 
-        log_info_printf(logsetup, "Bound %d to %s with sibling %s\n", sock.sock, name.c_str(), loSibling->name.c_str());
+    // join local group to receive
+    sock.mcast_join(lo_mcast_addr, lo_addr);
+    // setup for re-transmit
+    sock.mcast_ttl(1); // make default explicit, we will only send to lo_mcast_addr.
+    sock.mcast_loop(true);
+    sock.mcast_iface(lo_addr);
 
-    } else {
-        // join group to receive
-        sock.mcast_join(mcast_addr, lo_addr);
-        // setup for re-transmit
-        sock.mcast_ttl(1); // make default explicit
-        sock.mcast_loop(true);
-        sock.mcast_iface(lo_addr);
+    mcast_grps.emplace(lo_mcast_addr, lo_addr);
 
-        log_info_printf(logsetup, "Bound %d to %s as lo\n", sock.sock, name.c_str());
-    }
+    log_info_printf(logsetup, "Bound %d to %s as lo\n", sock.sock, name.c_str());
 
     if(event_add(rx.get(), nullptr))
         throw std::runtime_error("Unable to create collector Rx event");
 
-    if(loSibling)
-        loSibling->otherSiblings.insert(this);
-
-    manager->collectors[bind_addr] = this;
+    manager->collectors[bind_addr.port()] = this;
 }
 
 UDPCollector::~UDPCollector()
 {
     manager->loop.assertInLoop();
 
-    if(loSibling)
-        loSibling->otherSiblings.erase(this);
-
-    manager->collectors.erase(bind_addr);
+    manager->collectors.erase(bind_addr.port());
 
     // we should only be destroyed after that last listener has removed itself
     assert(listeners.empty());
     manager->loop.assertInLoop();
+}
+
+void UDPCollector::addListener(UDPListener *l)
+{
+    for(const auto& mcast : l->mcasts) {
+        const auto tup(std::make_pair(mcast, l->dest));
+        if(mcast_grps.find(tup)==mcast_grps.end()) {
+            mcast_grps.insert(tup);
+
+            log_debug_printf(logsetup, "collector joining %s on %s\n",
+                             mcast.tostring().c_str(),
+                             l->dest.tostring().c_str());
+
+            sock.mcast_join(mcast, l->dest);
+        }
+    }
+    listeners.insert(l);
+}
+
+void UDPCollector::delListener(UDPListener *l)
+{
+    listeners.erase(l);
+
+    // TODO: bother to cleanup mcast group membership?
+}
+
+// size of a CMD_ORIGIN_TAG prefix header
+static constexpr size_t cmd_origin_tag_size = 8 + 16;
+
+bool UDPCollector::handle_one()
+{
+    SockAddr dest;
+
+    buf.resize(cmd_origin_tag_size + 0x10000 + 1);
+    auto rxbuf = &buf[cmd_origin_tag_size];
+    auto rxlen = buf.size()-cmd_origin_tag_size-1;
+
+    // For Search messages, we use PV name strings in-place by adding nils.
+    // Ensure one extra byte at the end of the buffer for a nil after the last PV name
+    recvfromx rx{sock.sock, (char*)rxbuf, rxlen, &src, &dest};
+    const int nrx = rx.call();
+
+    if(nrx>=0 && rx.ndrop!=0u && prevndrop!=rx.ndrop) {
+        log_debug_printf(logio, "UDP collector socket buffer overflowed %u -> %u\n", unsigned(prevndrop), unsigned(rx.ndrop));
+        prevndrop = rx.ndrop;
+    }
+
+    if(nrx<0) {
+        int err = evutil_socket_geterror(sock.sock);
+        if(err==SOCK_EWOULDBLOCK || err==EAGAIN || err==SOCK_EINTR) {
+            // nothing to do here
+        } else {
+            log_warn_printf(logio, "UDP RX Error on %s : %s\n", name.c_str(),
+                            evutil_socket_error_to_string(err));
+        }
+        return false; // wait for more I/O
+
+    }
+
+    log_hex_printf(logio, Level::Debug, rxbuf, nrx, "UDP %d Rx %d, %s -> %s @%u (%s)\n",
+            sock.sock, nrx, src.tostring().c_str(), dest.tostring().c_str(), unsigned(rx.dstif), bind_addr.tostring().c_str());
+
+    origin_t origin = manager->ifmap.has_address(rx.dstif, lo_addr) ? Loopback : Remote;
+
+    process_one(dest, rxbuf, nrx, origin);
+    return true;
+}
+
+void UDPCollector::process_one(const SockAddr &dest, const uint8_t *buf, size_t nrx, origin_t origin)
+{
+    FixedBuf M(true, const_cast<uint8_t*>(buf), nrx);
+    Header head{};
+    from_wire(M, head); // overwrites M.be
+
+    if(!M.good() || (head.flags&(pva_flags::Control|pva_flags::SegMask))) {
+        // UDP packets can't contain control messages, or use segmentation
+
+        log_hex_printf(logio, Level::Debug, &buf[0], nrx, "Ignore UDP message from %s\n", src.tostring().c_str());
+        return;
+    }
+
+    names.clear();
+
+    if(head.len > M.size() && M.good()) {
+        log_info_printf(logio, "UDP ignore header%u %02x%02x%02x%02x on %s\n",
+                        unsigned(M.size()), M[0], M[1], M[2], M[3],
+                name.c_str());
+        return;
+    }
+
+    switch(head.cmd) {
+
+    case CMD_SEARCH: {
+        uint8_t flags = 0;
+        SockAddr replyAddr;
+        uint16_t port = 0;
+
+        from_wire(M, searchID);
+        auto save_flags = M.save();
+        from_wire(M, flags);
+        mustReply = flags&pva_search_flags::MustReply;
+
+        M.skip(3, __FILE__, __LINE__); // unused/reserved
+
+        auto save_replyAddr = M.save();
+        from_wire(M, replyAddr);
+        from_wire(M, port);
+        if(replyAddr.isAny()) {
+            replyAddr = src;
+            if(origin==OriginTag) {
+                log_err_printf(logio, "CMD_ORIGIN_TAG search with reply to sender never works%s", "\n");
+                return;
+            }
+        }
+        replyAddr.setPort(port);
+
+        if(M.good() && origin==Loopback && (flags&pva_search_flags::Unicast) && dest.family()!=AF_UNSPEC) {
+            assert(buf==&this->buf[cmd_origin_tag_size]);
+            // clear unicast flag in forwarded message
+            *save_flags &= ~pva_search_flags::Unicast;
+            // recipient of forwarded message must use, and trust, replyAddr in body :(
+            {
+                FixedBuf R(M.be, save_replyAddr, 16u);
+                to_wire(R, replyAddr);
+                assert(R.good());
+            }
+            forwardM(dest, buf, nrx);
+            return;
+        }
+
+        // so far, only "tcp" transport has ever been seen.
+        // however, we will consider and ignore any others which might appear
+        bool foundtcp = false;
+        Size nproto{0};
+        from_wire(M, nproto);
+        for(size_t i=0; i<nproto.size && M.good(); i++) {
+            Size nchar{0};
+            from_wire(M, nchar);
+
+            // shortcut to avoid allocating a std::string
+            // "tcp" is the only value we expect to see
+            foundtcp |= M.size()>=3 && nchar.size==3 && M[0]=='t' && M[1]=='c' && M[2]=='p';
+            M.skip(nchar.size, __FILE__, __LINE__);
+        }
+
+        // one Search message can include many PV names.
+        uint16_t nchan=0;
+        from_wire(M, nchan);
+
+        names.clear();
+        names.reserve(nchan);
+
+        for(size_t i=0; i<nchan && M.good(); i++) {
+            uint32_t id=0xffffffff; // poison
+            Size chlen{0};
+
+            auto mundge = M.save();
+            from_wire(M, id);
+            from_wire(M, chlen);
+            // inject nil for previous PV name
+            *mundge = '\0';
+            if(foundtcp && chlen.size<=M.size() && M.good()) {
+                names.push_back(UDPManager::Search::Name{reinterpret_cast<const char*>(M.save()), id});
+            }
+            M.skip(chlen.size, __FILE__, __LINE__);
+        }
+
+        // used by our reply()
+        src = replyAddr;
+
+        if(M.good()) {
+            // ensure nil for final PV name
+            *M.save() = '\0';
+
+            for(auto L : listeners) {
+                if(L->searchCB) {
+                    (L->searchCB)(*this);
+                }
+            }
+        }
+
+        break;
+    }
+
+    case CMD_BEACON: {
+        uint16_t port = 0;
+
+        _from_wire<12>(M, &beaconMsg.guid[0], false, __FILE__, __LINE__);
+        M.skip(4, __FILE__, __LINE__); // skip flags, seq, and change count.  unused
+        from_wire(M, beaconMsg.server);
+        from_wire(M, port);
+        if(beaconMsg.server.isAny()) {
+            beaconMsg.server = src;
+        }
+        beaconMsg.server.setPort(port);
+
+        std::string proto;
+        from_wire(M, proto);
+
+        // ignore remaining "server status" blob
+
+        if(M.good() && proto=="tcp") {
+            for(auto L : listeners) {
+                if(L->beaconCB) {
+                    (L->beaconCB)(beaconMsg);
+                }
+            }
+        }
+        break;
+    }
+
+    case CMD_ORIGIN_TAG: {
+        SockAddr originaddr; // aka. original destination
+        from_wire(M, originaddr);
+        M.skip(head.len-16u, __FILE__, __LINE__);
+
+        // only allow one CMD_ORIGIN_TAG message per packet
+        // only accept when sent to the mcast address from the loopback address
+        //   since we only join the mcast group on loopback this will hopefully
+        //   frustrate attempts to inject CMD_ORIGIN_TAG externally.
+        if(M.good() && origin==Loopback && dest.compare(lo_mcast_addr,false)==0 && src.isLO()) {
+            originaddr.setPort(bind_addr.port());
+
+            process_one(originaddr, M.save(), M.size(), OriginTag);
+
+            return;
+        }
+        log_debug_printf(logio, "Ignore originated from %s %c%c%c%c\n",
+                         originaddr.tostring().c_str(),
+                         M.good() ? 'T' : 'F',
+                         origin==Loopback ? 'T' : 'F',
+                         dest.compare(lo_mcast_addr,false)==0 ? 'T' : 'F',
+                         src.isLO() ? 'T' : 'F');
+
+        break;
+    }
+
+    default:
+        break; // ignore unknown
+    }
+}
+
+void UDPCollector::forwardM(const SockAddr& origin, const uint8_t *pbuf, size_t plen)
+{
+    log_debug_printf(logio, "Forward as originated for %s\n",
+                     origin.tostring().c_str());
+
+    assert(buf.size() > cmd_origin_tag_size);
+    assert(pbuf==&buf[cmd_origin_tag_size]);
+
+    {
+        FixedBuf M(true, &buf[0], cmd_origin_tag_size);
+
+        to_wire(M, Header{CMD_ORIGIN_TAG, 0, 16u});
+        to_wire(M, origin);
+        assert(M.good());
+        assert(M.save()==&buf[cmd_origin_tag_size]);
+    }
+
+    src = lo_mcast_addr;
+    reply(&buf[0], cmd_origin_tag_size+plen);
+}
+
+bool UDPCollector::reply(const void *msg, size_t msglen) const
+{
+    manager->loop.assertInLoop();
+
+    log_hex_printf(logio, Level::Debug, msg, msglen, "Send %s -> %s\n",
+                   bind_addr.tostring().c_str(), src.tostring().c_str());
+
+    int ntx = sendto(sock.sock, (char*)msg, msglen, 0, &src->sa, src.size());
+    if(ntx<0) {
+        int err = evutil_socket_geterror(sock.sock);
+        if(err==SOCK_EWOULDBLOCK || err==EAGAIN || err==SOCK_EINTR) {
+            // nothing to do here
+        } else {
+            log_warn_printf(logio, "UDP TX Error on %s -> %s : (%d) %s\n",
+                            name.c_str(), src.tostring().c_str(),
+                            err, evutil_socket_error_to_string(err));
+        }
+        return false; // wait for more I/O
+    }
+    return size_t(ntx)==msglen;
 }
 
 static struct udp_gbl_t {
@@ -425,7 +492,11 @@ epicsThreadOnceId collector_once = EPICS_THREAD_ONCE_INIT;
 void collector_init(void *unused)
 {
     (void)unused;
-    udp_gbl = new udp_gbl_t;
+    try {
+        udp_gbl = new udp_gbl_t;
+    }catch(std::exception& e){
+        log_exc_printf(logsetup, "Unable to alloc udp_gbl: %s\n", e.what());
+    }
 }
 } // namespace
 
@@ -504,7 +575,7 @@ UDPListener::UDPListener(const std::shared_ptr<UDPManager::Pvt> &manager, SockAd
     manager->loop.assertInLoop();
 
     collector = manager->collect(dest);
-    dest = collector->bind_addr;
+    dest.setPort(collector->bind_addr.port());
 }
 
 UDPListener::~UDPListener()
@@ -513,9 +584,20 @@ UDPListener::~UDPListener()
         // from event loop worker
 
         if(active)
-            collector->listeners.erase(this);
+            collector->delListener(this);
 
         collector.reset(); // destroy UDPCollector from worker
+    });
+}
+
+void UDPListener::addMCast(const SockAddr& mcast)
+{
+    manager->loop.call([this, &mcast](){
+        if(active)
+            throw std::logic_error("must addMCast() before start()");
+
+        collector->mcast_grps.emplace(mcast.withPort(collector->bind_addr.port()),
+                                      dest);
     });
 }
 
@@ -523,55 +605,14 @@ void UDPListener::start(bool s)
 {
     manager->loop.call([this, s](){
         if(s && !active) {
-            collector->listeners.insert(this);
+            collector->addListener(this);
 
         } else if(!s && active) {
-            collector->listeners.erase(this);
+            collector->delListener(this);
         }
 
         active = s;
     });
-}
-
-void UDPCollector::forwardM(const SockAddr& origin, const uint8_t* obuf, size_t olen)
-{
-    log_debug_printf(logio, "Forward as originated for %s\n",
-                     origin.tostring().c_str());
-
-    buf.resize(8+16+olen);
-    {
-        FixedBuf M(true, &buf[0], buf.size());
-
-        to_wire(M, Header{CMD_ORIGIN_TAG, 0, 16u});
-        to_wire(M, origin);
-        assert(M.good());
-        memcpy(M.save(), obuf, olen);
-    }
-
-    src = mcast_addr;
-    reply(&buf[0], buf.size());
-}
-
-bool UDPCollector::reply(const void *msg, size_t msglen) const
-{
-    manager->loop.assertInLoop();
-
-    log_hex_printf(logio, Level::Debug, msg, msglen, "Send %s -> %s\n",
-                   bind_addr.tostring().c_str(), src.tostring().c_str());
-
-    int ntx = sendto(sock.sock, (char*)msg, msglen, 0, &src->sa, src.size());
-    if(ntx<0) {
-        int err = evutil_socket_geterror(sock.sock);
-        if(err==SOCK_EWOULDBLOCK || err==EAGAIN || err==SOCK_EINTR) {
-            // nothing to do here
-        } else {
-            log_warn_printf(logio, "UDP TX Error on %s -> %s : (%d) %s\n",
-                            name.c_str(), src.tostring().c_str(),
-                            err, evutil_socket_error_to_string(err));
-        }
-        return false; // wait for more I/O
-    }
-    return size_t(ntx)==msglen;
 }
 
 UDPManager::Search::~Search() {}

--- a/src/udp_collector.cpp
+++ b/src/udp_collector.cpp
@@ -315,7 +315,7 @@ void UDPCollector::process_one(const SockAddr &dest, const uint8_t *buf, size_t 
         }
         server.setPort(port);
 
-        if(M.good() && origin==Loopback && (flags&pva_search_flags::Unicast) && dest.family()!=AF_UNSPEC) {
+        if(M.good() && origin==Loopback && (flags&pva_search_flags::Unicast) && dest.family()==AF_INET) {
             assert(buf==&this->buf[cmd_origin_tag_size]);
             // clear unicast flag in forwarded message
             *save_flags &= ~pva_search_flags::Unicast;

--- a/src/udp_collector.cpp
+++ b/src/udp_collector.cpp
@@ -383,12 +383,11 @@ void UDPCollector::process_one(const SockAddr &dest, const uint8_t *buf, size_t 
         }
         beaconMsg.server.setPort(port);
 
-        std::string proto;
-        from_wire(M, proto);
+        from_wire(M, beaconMsg.proto);
 
         // ignore remaining "server status" blob
 
-        if(M.good() && proto=="tcp") {
+        if(M.good()) {
             for(auto L : listeners) {
                 if(L->beaconCB) {
                     (L->beaconCB)(beaconMsg);

--- a/src/udp_collector.h
+++ b/src/udp_collector.h
@@ -35,10 +35,11 @@ struct PVXS_API UDPManager
     evbase& loop();
 
     struct Beacon {
-        SockAddr& src;
+        const SockAddr& src;
+        std::string proto;
         SockAddr server;
         ServerGUID guid;
-        Beacon(SockAddr& src) :src(src) {}
+        Beacon(const SockAddr& src) :src(src) {}
     };
     //! Create subscription for Beacon messages.
     //! Must call UDPListener::start()

--- a/src/udp_collector.h
+++ b/src/udp_collector.h
@@ -10,6 +10,7 @@
 #include <functional>
 #include <memory>
 #include <tuple>
+#include <set>
 #include <vector>
 #include <array>
 
@@ -83,11 +84,14 @@ private:
 
 class PVXS_API UDPListener
 {
+    friend struct UDPManager;
+
     std::function<void(UDPManager::Search&)> searchCB;
     std::function<void(UDPManager::Beacon&)> beaconCB;
     const std::shared_ptr<UDPManager::Pvt> manager;
     std::shared_ptr<UDPCollector> collector;
     const SockAddr dest;
+    std::set<SockAddr> mcasts;
     bool active;
 
     INST_COUNTER(UDPListener);
@@ -95,9 +99,11 @@ class PVXS_API UDPListener
     friend struct UDPCollector;
     friend struct UDPManager;
 
-public:
     UDPListener(const std::shared_ptr<UDPManager::Pvt>& manager, SockAddr& dest);
+public:
     ~UDPListener();
+
+    void addMCast(const SockAddr& mcast);
 
     void start(bool s=true);
     inline void stop() { start(false); }

--- a/src/udp_collector.h
+++ b/src/udp_collector.h
@@ -93,8 +93,6 @@ private:
 
 class PVXS_API UDPListener
 {
-    friend struct UDPManager;
-
     std::function<void(UDPManager::Search&)> searchCB;
     std::function<void(UDPManager::Beacon&)> beaconCB;
     const std::shared_ptr<UDPManager::Pvt> manager;

--- a/src/unittest.cpp
+++ b/src/unittest.cpp
@@ -50,6 +50,7 @@ void cleanup_for_valgrind()
 #endif
     impl::logger_shutdown();
     impl::UDPManager::cleanup();
+    IfaceMap::cleanup();
 }
 
 testCase::testCase()

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -350,6 +350,17 @@ bool SockAddr::isLO() const
     }
 }
 
+bool SockAddr::isMCast() const
+{
+    switch(store.sa.sa_family) {
+    case AF_INET: return IN_MULTICAST(store.in.sin_addr.s_addr);
+#ifdef AF_INET6
+    case AF_INET6: return IN6_IS_ADDR_MULTICAST(&store.in6.sin6_addr);
+#endif
+    default: return false;
+    }
+}
+
 std::string SockAddr::tostring() const
 {
     std::ostringstream strm;

--- a/src/utilpvt.h
+++ b/src/utilpvt.h
@@ -41,6 +41,8 @@
 #  endif
 #endif
 
+#include <epicsThread.h>
+
 namespace pvxs {namespace impl {
 
 //! in-line string builder (eg. for exception messages)
@@ -52,6 +54,9 @@ struct SB {
     template<typename T>
     SB& operator<<(const T& i) { strm<<i; return *this; }
 };
+
+
+void threadOnce(epicsThreadOnceId *id, EPICSTHREADFUNC fn, void *arg);
 
 namespace idetail {
 template <typename I>

--- a/src/utilpvt.h
+++ b/src/utilpvt.h
@@ -6,7 +6,7 @@
 #ifndef UTILPVT_H
 #define UTILPVT_H
 
-#include <osiSock.h>
+#include "osiSockExt.h"
 
 #ifdef _WIN32
 #  define WIN32_LEAN_AND_MEAN
@@ -195,71 +195,6 @@ using aligned_union = std::aligned_union<Len, Types...>;
 
 } // namespace impl
 using namespace impl;
-
-struct SockAttach {
-    SockAttach() { osiSockAttach(); }
-    ~SockAttach() { osiSockRelease(); }
-};
-
-// Linux specific SO_RXQ_OVFL exposes OS dropped packet counter
-void enable_SO_RXQ_OVFL(SOCKET sock);
-int recvfromx(SOCKET sock, void *buf, size_t buflen, sockaddr* peer, osiSocklen_t* peerlen, uint32_t *ndrop);
-
-//! representation of a network address
-struct PVXS_API SockAddr {
-    union store_t {
-        sockaddr sa;
-        sockaddr_in in;
-#ifdef AF_INET6
-        sockaddr_in6 in6;
-#endif
-    };
-private:
-    store_t  store;
-public:
-
-    explicit SockAddr(int af = AF_UNSPEC);
-    explicit SockAddr(int af, const char *address, unsigned short port=0);
-    explicit SockAddr(const sockaddr *addr, ev_socklen_t len);
-    inline explicit SockAddr(int af, const std::string& address) :SockAddr(af, address.c_str()) {}
-
-    size_t size() const;
-
-    inline unsigned short family() const { return store.sa.sa_family; }
-    unsigned short port() const;
-    void setPort(unsigned short port);
-    SockAddr withPort(unsigned short port) {
-        SockAddr temp(*this);
-        temp.setPort(port);
-        return temp;
-    }
-
-    void setAddress(const char *, unsigned short port=0);
-
-    bool isAny() const;
-    bool isLO() const;
-
-    store_t* operator->() { return &store; }
-    const store_t* operator->() const { return &store; }
-
-    std::string tostring() const;
-
-    static SockAddr any(int af, unsigned port=0);
-    static SockAddr loopback(int af, unsigned port=0);
-
-    inline bool operator<(const SockAddr& o) const {
-        return evutil_sockaddr_cmp(&store.sa, &o.store.sa, true)<0;
-    }
-    inline bool operator==(const SockAddr& o) const {
-        return evutil_sockaddr_cmp(&store.sa, &o.store.sa, true)==0;
-    }
-    inline bool operator!=(const SockAddr& o) const {
-        return !(*this==o);
-    }
-};
-
-PVXS_API
-std::ostream& operator<<(std::ostream& strm, const SockAddr& addr);
 
 inline
 timeval totv(double t)

--- a/src/utilpvt.h
+++ b/src/utilpvt.h
@@ -56,7 +56,7 @@ struct SB {
 };
 
 
-void threadOnce(epicsThreadOnceId *id, EPICSTHREADFUNC fn, void *arg);
+void threadOnce(epicsThreadOnceId *id, EPICSTHREADFUNC fn, void *arg=nullptr);
 
 namespace idetail {
 template <typename I>

--- a/test/Makefile
+++ b/test/Makefile
@@ -62,6 +62,10 @@ TESTPROD_HOST += testconfig
 testconfig_SRCS += testconfig.cpp
 TESTS += testconfig
 
+TESTPROD_HOST += testwild
+testwild_SRCS += testwild.cpp
+TESTS += testwild
+
 TESTPROD_HOST += testpvreq
 testpvreq_SRCS += testpvreq.cpp
 TESTS += testpvreq

--- a/test/testconfig.cpp
+++ b/test/testconfig.cpp
@@ -145,15 +145,47 @@ void testDefs()
     }
 }
 
+void testServerAuto()
+{
+    testShow()<<__func__;
+
+    /* We assume that the test host has at least
+     * one interface other than localhost configured.
+     * It need not be usable (eg. due to firewall).
+     */
+    server::Config conf;
+    conf.expand();
+
+    testFalse(conf.interfaces.empty())<<conf.interfaces;
+    testFalse(conf.beaconDestinations.empty())<<conf.beaconDestinations;
 }
+
+void testClientAuto()
+{
+    testShow()<<__func__;
+
+    /* We assume that the test host has at least
+     * one interface other than localhost configured.
+     * It need not be usable (eg. due to firewall).
+     */
+    client::Config conf;
+    conf.expand();
+
+    testFalse(conf.interfaces.empty())<<conf.interfaces;
+    testFalse(conf.addressList.empty())<<conf.addressList;
+}
+
+} // namespace
 
 MAIN(testconfig)
 {
-    testPlan(27);
+    testPlan(31);
     testSetup();
     testDefs();
     logger_config_env();
     testParse();
+    testServerAuto();
+    testClientAuto();
     cleanup_for_valgrind();
     return testDone();
 }

--- a/test/testget.cpp
+++ b/test/testget.cpp
@@ -502,7 +502,7 @@ MAIN(testget)
     testPlan(59);
     testSetup();
     logger_config_env();
-    bool canIPv6 = pvxs::impl::evsocket::canIPv6();
+    const bool canIPv6 = pvxs::impl::evsocket::canIPv6;
     Tester().testConnector();
     Tester().testWaiter();
     Tester(AF_INET).loopback();

--- a/test/testsock.cpp
+++ b/test/testsock.cpp
@@ -398,7 +398,7 @@ MAIN(testsock)
     testSetup();
     // check for behavior when binding ipv4 and ipv6 to the same socket
     // as a function of socket type and order.
-    if(evsocket::canIPv6()) {
+    if(evsocket::canIPv6) {
         // IPv4 and v6 loopback addresses are entirely distinct,
         // so no problem binding to both w/ or w/o IPV6_V6ONLY
         test_bind46("127.0.0.1" , "::1"       , SOCK_DGRAM  , 0);

--- a/test/testwild.cpp
+++ b/test/testwild.cpp
@@ -1,0 +1,111 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * pvxs is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+#define PVXS_ENABLE_EXPERT_API
+
+#include <atomic>
+
+#include <testMain.h>
+
+#include <epicsUnitTest.h>
+
+#include <epicsEvent.h>
+
+#include <pvxs/unittest.h>
+#include <pvxs/log.h>
+#include <pvxs/client.h>
+#include <pvxs/server.h>
+#include <pvxs/sharedpv.h>
+#include <pvxs/source.h>
+#include <pvxs/nt.h>
+#include "evhelper.h"
+
+namespace {
+using namespace pvxs;
+
+// Ensure we can setup a server and client on the wildcard interface(s).
+// bind()ing sockets and similar.
+// No operations are attempted as the default interface on some test systems
+// may have firewall rules blocking PVA traffic in and/or out.
+void testwildcard(const std::string& addr1, const std::string& addr2)
+{
+    testDiag("%s(%s, %s)", __func__,addr1.c_str(), addr2.c_str());
+
+    server::Config sconf;
+    sconf.tcp_port = sconf.udp_port = 0u; // choose randomly
+
+    if(!addr1.empty())
+        sconf.interfaces.push_back(addr1);
+    if(!addr2.empty())
+        sconf.interfaces.push_back(addr2);
+
+    auto serv(sconf.build());
+    sconf = serv.config();
+    testShow()<<"Server Config\n"<<sconf;
+
+    testNotEq(0u, sconf.udp_port);
+    testNotEq(0u, sconf.tcp_port);
+
+    auto cli(serv.clientConfig().build());
+    auto cconf(cli.config());
+    testShow()<<"Client Config\n"<<cconf;
+
+    testEq(sconf.udp_port, cconf.udp_port);
+    testEq(sconf.tcp_port, cconf.tcp_port);
+}
+
+// check logic for detection and fallback when requested TCP port
+// is already in use.
+void testconflict(const char* addr)
+{
+    testDiag("%s(\"%s\")", __func__, addr);
+
+    evsocket otherserver(AF_INET, SOCK_STREAM, 0);
+    otherserver.bind(SockAddr::any(AF_INET));
+    otherserver.listen(4);
+
+    server::Config iconf;
+    iconf.tcp_port = otherserver.sockname().port();
+    iconf.udp_port = 0u; // choose randomly
+    if(addr)
+        iconf.interfaces.push_back(addr);
+
+    auto serv(iconf.build());
+    auto fconf(serv.config());
+    testShow()<<"Server Config\n"<<iconf;
+
+    testNotEq(0u, fconf.udp_port)<<"w/ "<<addr;
+    testNotEq(iconf.tcp_port, fconf.tcp_port)<<"w/ "<<addr;
+}
+
+} // namespace
+
+MAIN(testwild)
+{
+    testPlan(18);
+    testSetup();
+    logger_config_env();
+    SockAttach attach;
+    const bool canIPv6 = pvxs::impl::evsocket::canIPv6;
+    testwildcard("", ""); // implies 0.0.0.0
+    testwildcard("0.0.0.0", "");
+    if(canIPv6) {
+        testwildcard("::", "");
+    } else {
+        testSkip(4, "No IPv6 Support");
+    }
+    if(evsocket::ipstack==evsocket::Linsock) {
+        testconflict("127.0.0.1");
+    } else {
+        testSkip(2, "Can bind both 0.0.0.0 and 127.0.0.1 to the same port");
+    }
+    testconflict("0.0.0.0");
+    if(canIPv6) {
+        testconflict("::");
+    } else {
+        testSkip(2, "No IPv6 Support");
+    }
+    return testDone();
+}

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -35,6 +35,9 @@ pvxcall_SRCS += call.cpp
 PROD += pvxlist
 pvxlist_SRCS += list.cpp
 
+PROD += pvxmshim
+pvxmshim_SRCS += mshim.cpp
+
 #===========================
 
 include $(TOP)/configure/RULES

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -32,6 +32,9 @@ pvxput_SRCS += put.cpp
 PROD += pvxcall
 pvxcall_SRCS += call.cpp
 
+PROD += pvxlist
+pvxlist_SRCS += list.cpp
+
 #===========================
 
 include $(TOP)/configure/RULES

--- a/tools/list.cpp
+++ b/tools/list.cpp
@@ -1,0 +1,213 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * pvxs is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+
+#include <iostream>
+#include <sstream>
+#include <map>
+#include <set>
+#include <list>
+#include <atomic>
+
+#include <epicsVersion.h>
+#include <epicsGetopt.h>
+#include <epicsThread.h>
+
+#include <pvxs/client.h>
+#include <pvxs/nt.h>
+#include <pvxs/log.h>
+#include "utilpvt.h"
+#include "evhelper.h"
+
+using namespace pvxs;
+
+namespace {
+
+void usage(const char* argv0)
+{
+    std::cerr<<
+            "Usage:\n"
+            "  Discover Servers:\n"
+            "    "<<argv0<<" [options]\n"
+            "\n"
+            "  List PVs:\n"
+            "    "<<argv0<<" [options] <IP[:Port] ...>\n"
+            "\n"
+            "  Server Info:\n"
+            "    "<<argv0<<" [options] -i <IP[:Port] ...>\n"
+            "\n"
+            "Examples:\n"
+            "  Monitor server beacons to detect servers coming online, and going offline.\n"
+            "   "<<argv0<<" -w 0 -v\n"
+            "\n"
+            "  List all PV names.  (Warning: high network load)\n"
+            "   "<<argv0<<" -w 5 | "<<argv0<<"\n"
+            "\n"
+            "  -h        Show this message.\n"
+            "  -V        Print version and exit.\n"
+            "  -A        Active discovery mode (default).  Send broadcast pint, then continue\n"
+            "            listening for Beacons.\n"
+            "            Warning: Active discovery pings result in a lot of network traffic.\n"
+            "  -p        Passive discovery mode.  Only listen for server Beacons.\n"
+            "  -i        Query server info.  Requires address(es)\n"
+            "  -v        Make more noise.\n"
+            "  -d        Shorthand for $PVXS_LOG=\"pvxs.*=DEBUG\".  Make a lot of noise.\n"
+            "  -w <sec>  Operation timeout in seconds.  Default 5 sec.  '0' disables timeout,\n"
+            "            useful in combination with '-v'.\n"
+            ;
+}
+
+} // namespace
+
+int main(int argc, char *argv[])
+{
+    try {
+        logger_config_env(); // from $PVXS_LOG
+        double timeout = 5.0;
+        bool verbose = false;
+        bool info = false;
+        bool active = true;
+
+        {
+            int opt;
+            while ((opt = getopt(argc, argv, "hVApivdw:")) != -1) {
+                switch(opt) {
+                case 'h':
+                    usage(argv[0]);
+                    return 0;
+                case 'V':
+                    std::cout<<version_str()<<"\n";
+                    std::cout<<EPICS_VERSION_STRING<<"\n";
+                    std::cout<<"libevent "<<event_get_version()<<"\n";
+                    return 0;
+                case 'A':
+                    active = true;
+                    break;
+                case 'p':
+                    active = false;
+                    break;
+                case 'i':
+                    info = true;
+                    break;
+                case 'v':
+                    verbose = true;
+                    break;
+                case 'd':
+                    logger_level_set("pvxs.*", Level::Debug);
+                    break;
+                case 'w':
+                    timeout = parseTo<double>(optarg);
+                    break;
+                default:
+                    usage(argv[0]);
+                    std::cerr<<"\nUnknown argument: "<<char(opt)<<std::endl;
+                    return 1;
+                }
+            }
+        }
+
+        if(info && optind==argc) {
+            usage(argv[0]);
+            std::cerr<<"\nError: -i requires at least one server"<<std::endl;
+            return 1;
+        }
+
+        auto ctxt(client::Context::fromEnv());
+        auto conf = ctxt.config();
+
+        epicsEvent done;
+        SigInt H([&done]() {
+            done.signal();
+        });
+
+        std::vector<std::shared_ptr<client::Operation>> ops;
+        ops.reserve(argc-optind);
+
+        if(optind==argc) { // discover mode, search of all servers
+            std::set<std::pair<ServerGUID, std::string>> servprotos;
+
+            ops.push_back(ctxt.discover([servprotos, verbose](const client::Discovered& serv) mutable {
+                if(verbose) { // print all events and info
+                    std::cout<<serv<<std::endl;
+
+                } else if(serv.proto=="tcp") { // print only new TCP server endpoints
+                    const auto key(std::make_pair(serv.guid, serv.proto));
+
+                    if(serv.event==client::Discovered::Timeout) {
+                        servprotos.erase(key);
+
+                    } else if(servprotos.find(key)!=servprotos.end()) {
+                        /* Previously listed server and protocol, through different interface.
+                         * we arbitrarily print just one interface on the theory that the list
+                         * of servers is being piped back to fetch a list of PVs
+                         */
+
+                    } else {
+                        servprotos.insert(key);
+                        std::cout<<serv.server<<std::endl;
+                    }
+                }
+            })
+                          .pingAll(active)
+                          .exec());
+
+        } else { // query mode, fetch info from specific servers
+
+            std::atomic<int> remaining{argc-optind};
+
+            for(auto n : range(optind, argc)) {
+                ops.push_back(ctxt.rpc("server")
+                              .server(argv[n])
+                              .arg("op", info ? "info" : "channels")
+                              .result([argv, n, info, verbose, &remaining, &done](client::Result&& r)
+                      {
+                          try {
+                              auto top(r());
+
+                              if(info) {
+                                  std::cout<<argv[n];
+                                  std::string temp;
+                                  if(top["version"].as(temp)) {
+                                      std::cout<<" version=\""<<escape(temp)<<"\"";
+                                  };
+                                  if(top["implLang"].as(temp)) {
+                                      std::cout<<" lang=\""<<escape(temp)<<"\"";
+                                  };
+                                  std::cout<<"\n";
+
+                              } else { // channels
+                                  if(verbose)
+                                      std::cout<<"# From "<<argv[n]<<"\n";
+
+                                  auto channels(top["value"].as<shared_array<const std::string>>());
+                                  for(auto& name : channels) {
+                                      std::cout<<name<<"\n";
+                                  }
+                              }
+                              std::cout.flush();
+                          }catch(std::exception& e){
+                              std::cerr<<"From "<<argv[n]<<" : "<<e.what()<<std::endl;
+                          }
+
+                          if(0==--remaining) {
+                              done.signal();
+                          }
+                      })
+                              .exec());
+            }
+        }
+
+        if(timeout>0.0)
+            done.wait(timeout);
+        else
+            done.wait();
+
+        return 0;
+
+    }catch(std::exception& e){
+        std::cerr<<"Error: "<<e.what()<<"\n";
+        return 1;
+    }
+}

--- a/tools/mshim.cpp
+++ b/tools/mshim.cpp
@@ -1,0 +1,302 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * pvxs is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+
+#include <map>
+#include <vector>
+#include <iostream>
+#include <string>
+#include <exception>
+
+#include <epicsVersion.h>
+#include <epicsGetopt.h>
+
+#include <pvxs/log.h>
+#include <pvxs/server.h>
+#include "utilpvt.h"
+#include "evhelper.h"
+#include "udp_collector.h"
+
+using namespace pvxs;
+
+DEFINE_LOGGER(applog, "mshim");
+
+namespace {
+
+void usage(const char* argv0)
+{
+    std::cerr<<
+                "Usage: "<<argv0<<" [-L <ip>[@iface]]... [-F]\n"
+                "\n"
+                "  -L <ip>                 Interface address to listen on.\n"
+                "  -L <ip>[@iface]         Join multicast group, optionally via a certain interface\n"
+                "                          to override the default selected by the OS.\n"
+                "  -F <ip>                 Forward received packets to destination unicast/broadcast address.\n"
+                "  -F <ip>[,ttl#][@iface]  Forward received packets to destination multicast group.\n"
+                "                          Optionally override OS default TTL and outbound interface selected\n"
+                "                          by the OS.\n"
+                "  -p <port#>              Default port number.  (overrides $EPICS_PVA_BROADCAST_PORT)\n"
+                "  -h                      Show this message.\n"
+                "  -V                      Show versions.\n"
+                "\n"
+                "  Compatibility shim for IPv4 multicast by non-aware PVA clients/servers.\n"
+                "\n"
+                "  Examples:\n"
+                "\n"
+                "    1. Forwarding searches from local clients to a multicast group via the default interface.\n"
+                "    2. Forwarding beacons from multicast group via the default interface to local clients.\n"
+                "\n"
+                "    "<<argv0<<" -L 127.0.0.1:15076 -F 224.1.1.1,255 &  # 1\n"
+                "    "<<argv0<<" -L 224.1.1.1,255 -F 127.0.0.1:15076 &  # 2\n"
+    <<std::endl;
+}
+
+SockEndpoint parseEP(const char* optarg, const server::Config& conf)
+{
+    SockEndpoint ep;
+    try {
+        ep = SockEndpoint(optarg, conf.udp_port);
+
+    }catch(std::exception& e){
+        std::cerr<<"Error: Invalid group spec. '"<<escape(optarg)<<"' : "<<e.what()<<std::endl;
+        exit(1);
+    }
+    if(ep.addr.family()!=AF_INET) {
+        std::cerr<<"Only IPv4 addresses are supported"<<std::endl;
+        exit(1);
+
+    } else if(ep.addr.port()==0) {
+        std::cerr<<"Non-zero port number required"<<std::endl;
+        exit(1);
+    }
+    return ep;
+}
+
+struct App {
+    const SockAttach attach;
+    IfaceMap& ifmap;
+    const evsocket sockTx{AF_INET, SOCK_DGRAM, 0};
+    std::vector<SockEndpoint> destinations;
+
+    // effectively local to UDPManager worker
+    std::vector<uint8_t> scratch;
+
+    App()
+        :ifmap(IfaceMap::instance())
+        ,scratch(0x10000)
+    {
+        auto bind_addr(SockAddr::any(sockTx.af));
+        sockTx.bind(bind_addr);
+        sockTx.mcast_loop(true);
+    }
+
+    void onSearch(const UDPManager::Search& msg)
+    {
+        FixedBuf buf(true, scratch);
+        auto save_header = buf.save();
+        buf._skip(8);
+        to_wire(buf, msg.searchID);
+        auto save_flags = buf.save();
+        to_wire(buf, {
+                    uint8_t(msg.mustReply ? pva_search_flags::MustReply : 0u),
+                    0,0,0
+                });
+        assert(!msg.server.isAny() && msg.server.family()==AF_INET); // UDPManager has already handled this case
+        to_wire(buf, msg.server);
+        to_wire(buf, uint16_t(msg.server.port()));
+
+        size_t nproto = msg.otherproto.size();
+        if(msg.protoTCP)
+            nproto++;
+
+        to_wire(buf, Size{nproto});
+        if(msg.protoTCP)
+            to_wire(buf, "tcp");
+        for(auto& prot : msg.otherproto) {
+            to_wire(buf, prot);
+        }
+
+        to_wire(buf, uint16_t(msg.names.size()));
+
+        for(auto& name : msg.names) {
+            to_wire(buf, name.id);
+            to_wire(buf, name.name);
+        }
+
+        if(!buf.good()) {
+            log_warn_printf(applog, "Unable to construct CMD_SEARCH to forward. %s:%d\n",
+                            buf.file(), buf.line());
+            return;
+        }
+
+        auto bufsize = buf.save()-save_header;
+        {
+            FixedBuf buf(true, save_header, 8u);
+            to_wire(buf, Header{CMD_SEARCH, 0, uint32_t(bufsize-8u)});
+        }
+
+        for(auto& dest : destinations) {
+            if(dest.addr.isMCast() || ifmap.is_broadcast(dest.addr)) {
+                *save_flags &= ~pva_search_flags::Unicast;
+
+            } else {
+                *save_flags |= pva_search_flags::Unicast;
+            }
+
+            sockTx.mcast_prep_sendto(dest);
+
+            auto ret = sendto(sockTx.sock, (char*)scratch.data(), bufsize, 0,
+                              &dest.addr->sa, dest.addr.size());
+
+            if(ret < 0) {
+                int err = evutil_socket_geterror(sockTx.sock);
+                if(err==SOCK_EWOULDBLOCK || err==EAGAIN || err==SOCK_EINTR) {
+                    break; // too bad, better luck next time
+
+                } else {
+                    log_warn_printf(applog, "Unable to send search to %s, skip.  (%d) %s\n",
+                                    std::string(SB()<<dest).c_str(), err, evutil_socket_error_to_string(err));
+                }
+
+            } else if(ret!=bufsize) {
+                log_warn_printf(applog, "Sent truncated search to %s?\n",
+                                std::string(SB()<<dest).c_str());
+
+            } else {
+                log_debug_printf(applog, "Forwarded search to %s -> %s -> %s?\n",
+                                 msg.src.tostring().c_str(),
+                                 msg.server.tostring().c_str(),
+                                 std::string(SB()<<dest).c_str());
+            }
+        }
+    }
+
+    void onBeacon(const UDPManager::Beacon& msg)
+    {
+        FixedBuf buf(true, scratch);
+        auto save_header = buf.save();
+        buf._skip(8);
+        _to_wire<12>(buf, msg.guid.data(), false, __FILE__, __LINE__);
+        to_wire(buf, uint32_t(0u)); // skip flags, seq, and change count.  unused
+        assert(!msg.server.isAny() && msg.server.family()==AF_INET); // UDPManager has already handled this case
+        to_wire(buf, msg.server);
+        to_wire(buf, uint16_t(msg.server.port()));
+        to_wire(buf, msg.proto);
+        // "NULL" serverStatus
+        to_wire(buf, uint8_t(0xff));
+
+        if(!buf.good()) {
+            log_warn_printf(applog, "Unable to construct CMD_SEARCH to forward. %s:%d\n",
+                            buf.file(), buf.line());
+            return;
+        }
+
+        auto bufsize = buf.save()-save_header;
+        {
+            FixedBuf buf(true, save_header, 8u);
+            to_wire(buf, Header{CMD_SEARCH, 0, uint32_t(bufsize-8u)});
+        }
+
+        for(auto& dest : destinations) {
+            sockTx.mcast_prep_sendto(dest);
+
+            auto ret = sendto(sockTx.sock, (char*)scratch.data(), bufsize, 0,
+                              &dest.addr->sa, dest.addr.size());
+
+            if(ret < 0) {
+                int err = evutil_socket_geterror(sockTx.sock);
+                if(err==SOCK_EWOULDBLOCK || err==EAGAIN || err==SOCK_EINTR) {
+                    break; // too bad, better luck next time
+
+                } else {
+                    log_warn_printf(applog, "Unable to send beacon to %s, skip.  (%d) %s\n",
+                                    std::string(SB()<<dest).c_str(), err, evutil_socket_error_to_string(err));
+                }
+
+            } else if(ret!=bufsize) {
+                log_warn_printf(applog, "Sent truncated beacon to %s?\n",
+                                std::string(SB()<<dest).c_str());
+
+            } else {
+                log_debug_printf(applog, "Forwarded beacon to %s -> %s -> %s?\n",
+                                 msg.src.tostring().c_str(),
+                                 msg.server.tostring().c_str(),
+                                 std::string(SB()<<dest).c_str());
+            }
+        }
+    }
+};
+
+} // namespace
+
+int main(int argc, char *argv[])
+{
+    try {
+        SockAttach attach;
+        logger_config_env();
+        App app;
+
+        auto conf(server::Config::fromEnv());
+        auto manager(UDPManager::instance());
+        std::vector<std::unique_ptr<UDPListener>> listeners;
+
+        auto onS = [&app](const UDPManager::Search& msg) {app.onSearch(msg);};
+        auto onB = [&app](const UDPManager::Beacon& msg) {app.onBeacon(msg);};
+
+        {
+            int opt;
+            while ((opt = getopt(argc, argv, "L:F:phV")) != -1) {
+                switch(opt) {
+                case 'L':
+                {
+                    SockEndpoint ep(parseEP(optarg, conf));
+                    listeners.push_back(manager.onSearch(ep, onS));
+                    listeners.push_back(manager.onBeacon(ep, onB));
+                    break;
+                }
+                case 'F':
+                    app.destinations.push_back(parseEP(optarg, conf));
+                    break;
+                case 'p':
+                    conf.udp_port = parseTo<uint64_t>(optarg);
+                    break;
+                case 'h':
+                    usage(argv[0]);
+                    return 0;
+                case 'V':
+                    std::cout<<version_str()<<"\n";
+                    std::cout<<EPICS_VERSION_STRING<<"\n";
+                    std::cout<<"libevent "<<event_get_version()<<std::endl;
+                    return 0;
+                default:
+                    usage(argv[0]);
+                    std::cerr<<"\nError: Unknown argument: "<<char(opt)<<std::endl;
+                    return 1;
+                }
+            }
+        }
+
+        if(argc!=optind) {
+            usage(argv[0]);
+            std::cerr<<"Error: Unexpected arguments."<<std::endl;
+            return 1;
+        }
+
+        for(auto& listener : listeners) {
+            listener->start();
+        }
+
+        epicsEvent done;
+        SigInt H([&done]() {
+            done.signal();
+        });
+        done.wait();
+
+        return 0;
+    }catch(std::exception& e){
+        std::cerr<<"Error: "<<e.what()<<"\n";
+        return 1;
+    }
+}

--- a/tools/pvxvct.cpp
+++ b/tools/pvxvct.cpp
@@ -232,8 +232,8 @@ int main(int argc, char *argv[])
                 return;
 
             const auto& guid = msg.guid;
-            log_debug_printf(out, "%s\n",
-                             std::string(pva::impl::SB()<<msg.src<<" Beacon "<<guid<<' '<<msg.server).c_str());
+            log_info_printf(out, "%s\n",
+                            std::string(pva::impl::SB()<<msg.src<<" Beacon "<<guid<<' '<<msg.server).c_str());
 
         };
 


### PR DESCRIPTION
Added support for multicast search and beacons over IPv4 and IPV6.

## User configuration

EPICS_PVA_ADDR_LIST and friends accept expanded entries of the form `<IP>[:port][,TTL#][@iface]`.  Where IP may be IPv4 dotted quad or an IPv6 address enclosed in square brackets.  Some examples:

* `192.168.1.1` as before is a unicast address
* `224.0.2.3,255@192.168.1.1` specifies a multicast group `224.0.2.3` reached via the interface with address `192.168.1.1` where UDP packets sent will have TTL of 255.
* `ff02::42:1,1@br0` an IPv6 link scope multicast group `ff02::42:1` reached via the interface `br0`, using a TTL of 1.  (this being a rough functional equivalent to an IPv4 broadcast address)

Note that the `@` syntax is overlapping with the IPV6 specific `#` syntax for specifying interfaces.  Currently this is always resolved in favor of the `@` syntax.

## Sockets

* By default a TCP socket bound to `0.0.0.0` will be "upgraded" to an IPv6 socket bound to `::` allowing incoming connections over either IP version.
* Sockets bound to a specific IPv4 or IPv6 address will of course be limited to that IP version.
* UDP sockets are limited to either IPv4 or IPv6 as it is not possible for an `AF_INET6` socket to interact with IPv4 multicast groups through 4to6 address mapping.

## Current State

At present IPv6 UDP handling must be explicitly enabled.