### PR TITLE
fix handling of `pva_ctrl_msg::SetEndian`

### DIFF
--- a/documentation/releasenotes.rst
+++ b/documentation/releasenotes.rst
@@ -6,6 +6,7 @@ Release Notes
 0.3.0 (UNRELEASED)
 ------------------
 
+* Fix protocol **incompatibility** with Big Endian servers.
 * Add support for IPv4 multicast and IPv6 uni/multicast for UDP.  And IPv6 unicast for TCP.
   See :ref:`addrspec` for entries which may now appear in **EPICS_PVA*_ADDR_LIST**.
 * PVXS now attempts to fanout unicast searches through the loopback interface, and

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -140,7 +140,7 @@ void Channel::disconnect(const std::shared_ptr<Channel>& self)
         {
             (void)evbuffer_drain(current->txBody.get(), evbuffer_get_length(current->txBody.get()));
 
-            EvOutBuf R(hostBE, current->txBody.get());
+            EvOutBuf R(current->sendBE, current->txBody.get());
 
             to_wire(R, sid);
             to_wire(R, cid);

--- a/src/clientconn.cpp
+++ b/src/clientconn.cpp
@@ -67,7 +67,7 @@ void Connection::createChannels()
         {
             (void)evbuffer_drain(txBody.get(), evbuffer_get_length(txBody.get()));
 
-            EvOutBuf R(hostBE, txBody.get());
+            EvOutBuf R(sendBE, txBody.get());
 
             to_wire(R, uint16_t(1u));
             to_wire(R, chan->cid);
@@ -90,7 +90,7 @@ void Connection::sendDestroyRequest(uint32_t sid, uint32_t ioid)
     {
         (void)evbuffer_drain(txBody.get(), evbuffer_get_length(txBody.get()));
 
-        EvOutBuf R(hostBE, txBody.get());
+        EvOutBuf R(sendBE, txBody.get());
 
         to_wire(R, sid);
         to_wire(R, ioid);
@@ -232,7 +232,7 @@ void Connection::handle_CONNECTION_VALIDATION()
     {
         (void)evbuffer_drain(txBody.get(), evbuffer_get_length(txBody.get()));
 
-        EvOutBuf R(hostBE, txBody.get());
+        EvOutBuf R(sendBE, txBody.get());
 
         // serverReceiveBufferSize, not used
         to_wire(R, uint32_t(0x10000));
@@ -316,7 +316,7 @@ void Connection::handle_CREATE_CHANNEL()
                 {
                     (void)evbuffer_drain(txBody.get(), evbuffer_get_length(txBody.get()));
 
-                    EvOutBuf R(hostBE, txBody.get());
+                    EvOutBuf R(sendBE, txBody.get());
                     to_wire(R, sid);
                     to_wire(R, cid);
                 }
@@ -400,7 +400,7 @@ void Connection::tickEcho()
 
     auto tx = bufferevent_get_output(bev.get());
 
-    to_evbuf(tx, Header{CMD_ECHO, 0u, 0u}, hostBE);
+    to_evbuf(tx, Header{CMD_ECHO, 0u, 0u}, sendBE);
 
     // maybe help reduce latency
     bufferevent_flush(bev.get(), EV_WRITE, BEV_FLUSH);

--- a/src/clientget.cpp
+++ b/src/clientget.cpp
@@ -286,9 +286,11 @@ struct GPROp : public OperationBase
         // act on new operation state
 
         {
-            (void)evbuffer_drain(chan->conn->txBody.get(), evbuffer_get_length(chan->conn->txBody.get()));
+            auto& conn = chan->conn;
 
-            EvOutBuf R(hostBE, chan->conn->txBody.get());
+            (void)evbuffer_drain(conn->txBody.get(), evbuffer_get_length(conn->txBody.get()));
+
+            EvOutBuf R(conn->sendBE, conn->txBody.get());
 
             to_wire(R, chan->sid);
             to_wire(R, ioid);
@@ -339,7 +341,7 @@ struct GPROp : public OperationBase
         {
             (void)evbuffer_drain(conn->txBody.get(), evbuffer_get_length(conn->txBody.get()));
 
-            EvOutBuf R(hostBE, conn->txBody.get());
+            EvOutBuf R(conn->sendBE, conn->txBody.get());
 
             to_wire(R, chan->sid);
             to_wire(R, ioid);

--- a/src/clientintrospect.cpp
+++ b/src/clientintrospect.cpp
@@ -83,7 +83,7 @@ struct InfoOp : public OperationBase
         {
             (void)evbuffer_drain(conn->txBody.get(), evbuffer_get_length(conn->txBody.get()));
 
-            EvOutBuf R(hostBE, conn->txBody.get());
+            EvOutBuf R(conn->sendBE, conn->txBody.get());
 
             to_wire(R, chan->sid);
             to_wire(R, ioid);

--- a/src/clientmon.cpp
+++ b/src/clientmon.cpp
@@ -116,7 +116,7 @@ struct SubscriptionImpl : public OperationBase, public Subscription
 
                     (void)evbuffer_drain(conn->txBody.get(), evbuffer_get_length(conn->txBody.get()));
 
-                    EvOutBuf R(hostBE, conn->txBody.get());
+                    EvOutBuf R(conn->sendBE, conn->txBody.get());
 
                     to_wire(R, chan->sid);
                     to_wire(R, ioid);
@@ -272,7 +272,7 @@ struct SubscriptionImpl : public OperationBase, public Subscription
 
             (void)evbuffer_drain(conn->txBody.get(), evbuffer_get_length(conn->txBody.get()));
 
-            EvOutBuf R(hostBE, conn->txBody.get());
+            EvOutBuf R(conn->sendBE, conn->txBody.get());
 
             to_wire(R, chan->sid);
             to_wire(R, ioid);
@@ -360,7 +360,7 @@ struct SubscriptionImpl : public OperationBase, public Subscription
             {
                 (void)evbuffer_drain(conn->txBody.get(), evbuffer_get_length(conn->txBody.get()));
 
-                EvOutBuf R(hostBE, conn->txBody.get());
+                EvOutBuf R(conn->sendBE, conn->txBody.get());
 
                 to_wire(R, chan->sid);
                 to_wire(R, ioid);

--- a/src/conn.h
+++ b/src/conn.h
@@ -27,6 +27,7 @@ struct ConnBase
     TypeStore rxRegistry;
 
     const bool isClient;
+    bool sendBE;
     bool peerBE;
     bool expectSeg;
 

--- a/src/serverchan.cpp
+++ b/src/serverchan.cpp
@@ -163,7 +163,7 @@ void ServerChannelControl::close()
                              conn->peerName.c_str(), ch->name.c_str());
 
             auto tx = bufferevent_get_output(conn->bev.get());
-            EvOutBuf R(hostBE, tx);
+            EvOutBuf R(conn->sendBE, tx);
             to_wire(R, Header{CMD_DESTROY_CHANNEL, pva_flags::Server, 8});
             to_wire(R, ch->sid);
             to_wire(R, ch->cid);
@@ -251,7 +251,7 @@ void ServerConn::handle_SEARCH()
     {
         (void)evbuffer_drain(txBody.get(), evbuffer_get_length(txBody.get()));
 
-        EvOutBuf R(hostBE, txBody.get());
+        EvOutBuf R(sendBE, txBody.get());
 
         _to_wire<12>(R, iface->server->effective.guid.data(), false, __FILE__, __LINE__);
         to_wire(R, searchID);
@@ -363,7 +363,7 @@ void ServerConn::handle_CREATE_CHANNEL()
         {
             (void)evbuffer_drain(txBody.get(), evbuffer_get_length(txBody.get()));
 
-            EvOutBuf R(hostBE, txBody.get());
+            EvOutBuf R(sendBE, txBody.get());
             to_wire(R, cid);
             to_wire(R, sid);
             to_wire(R, sts);
@@ -417,7 +417,7 @@ void ServerConn::handle_DESTROY_CHANNEL()
 
     {
         auto tx = bufferevent_get_output(bev.get());
-        EvOutBuf R(hostBE, tx);
+        EvOutBuf R(sendBE, tx);
         to_wire(R, Header{CMD_DESTROY_CHANNEL, pva_flags::Server, 8});
         to_wire(R, sid);
         to_wire(R, cid);

--- a/src/serverget.cpp
+++ b/src/serverget.cpp
@@ -69,7 +69,7 @@ struct ServerGPR : public ServerOp
         {
             (void)evbuffer_drain(conn->txBody.get(), evbuffer_get_length(conn->txBody.get()));
 
-            EvOutBuf R(hostBE, conn->txBody.get());
+            EvOutBuf R(conn->sendBE, conn->txBody.get());
             to_wire(R, uint32_t(ioid));
             to_wire(R, subcmd);
             to_wire(R, sts);

--- a/src/serverintrospect.cpp
+++ b/src/serverintrospect.cpp
@@ -35,7 +35,7 @@ struct ServerIntrospect : public ServerOp
         {
             (void)evbuffer_drain(conn->txBody.get(), evbuffer_get_length(conn->txBody.get()));
 
-            EvOutBuf R(hostBE, conn->txBody.get());
+            EvOutBuf R(conn->sendBE, conn->txBody.get());
             to_wire(R, uint32_t(ioid));
             to_wire(R, sts);
             if(type)

--- a/src/servermon.cpp
+++ b/src/servermon.cpp
@@ -120,7 +120,7 @@ struct MonitorOp : public ServerOp,
         {
             (void)evbuffer_drain(conn->txBody.get(), evbuffer_get_length(conn->txBody.get()));
 
-            EvOutBuf R(hostBE, conn->txBody.get());
+            EvOutBuf R(conn->sendBE, conn->txBody.get());
             to_wire(R, uint32_t(ioid));
             to_wire(R, subcmd);
             if(subcmd&0x08) {


### PR DESCRIPTION
Address my mis-reading of the protocol "spec" (https://github.com/epics-base/pvAccessCPP/issues/183) by respecting `pva_flags::MSB` only when `pva_ctrl_msg::SetEndian` is received.  However, still not inspecting the `size` field for `pva_ctrl_msg::SetEndian`.  This brings PVXS in line with pvAccessCPP.