### PR TITLE
fix C++17 build

### DIFF
--- a/src/pvxs/client.h
+++ b/src/pvxs/client.h
@@ -854,7 +854,7 @@ public:
         return _buildReq();
     }
 };
-RequestBuilder Context::request() { return RequestBuilder{}; }
+RequestBuilder Context::request() { return RequestBuilder(); }
 
 //! cf. Context::connect()
 //! @since 0.2.0


### PR DESCRIPTION
While trying to compile `pvxs` to see if I could package it using meson, I came across an unrelated compilation error:

```
pvxs> In file included from ../src/describe.cpp:19:
pvxs> ../src/pvxs/client.h: In static member function 'static pvxs::client::RequestBuilder pvxs::client::Context::request()':
pvxs> ../src/pvxs/client.h:860:59: error: 'pvxs::client::detail::CommonBuilder<SubBuilder, Base>::CommonBuilder() [with SubBuilder = pvxs::client::RequestBuilder; Base = pvxs::client::detail::CommonBase]' is protected within this context
pvxs>   860 | RequestBuilder Context::request() { return RequestBuilder{}; }
pvxs>       |                                                           ^
pvxs> ../src/pvxs/client.h:595:5: note: declared protected here
pvxs>   595 |     CommonBuilder() = default;
pvxs>       |     ^~~~~~~~~~~~~
```

And after a bit of searching for the cause, I found that this error is present only when the C++ standard is `c++17` or above on both GCC and Clang:

https://godbolt.org/z/cW18s13fo

As I understood it, C++17 allows [aggregate initialisation][1] for classes which have public base classes. This changes the line from a statement calling the default constructor, to a statement performing aggregate initialisation, and the base class is default initialized.

In other words, in C++17, the line:

```cpp
return RequestBuilder{};
```

is understood as:

```cpp
return RequestBuilder{CommonBuilder<...>{}};
```

And since the default-constructor of CommonBuilder is protected, GCC and Clang errors out.

Here, we explicitely call the default constructor, implicitely defined in RequestBuilder.

The only weird thing I can't wrap my head around, is why if the base class has no other constructor than the default one, no error is produced...

This fixes builds using GCC 11+ since it defaults to C++17.

[1]: https://en.cppreference.com/w/cpp/language/aggregate_initialization