### PR TITLE
allow TypeDef to append StructA and UnionA

### DIFF
--- a/src/type.cpp
+++ b/src/type.cpp
@@ -341,8 +341,8 @@ Member TypeDef::as(const std::string& name) const
 
 std::shared_ptr<Member> TypeDef::_append_start()
 {
-    if(!top || (top->code!=TypeCode::Struct && top->code!=TypeCode::Union))
-        throw std::logic_error("May only append to Struct or Union");
+    if(!top || (top->code.scalarOf()!=TypeCode::Struct && top->code.scalarOf()!=TypeCode::Union))
+        throw std::logic_error("May only append to Struct, Union, StructA, or UnionA");
 
     std::shared_ptr<Member> edit;
     if(top.use_count()==1u) {

--- a/test/testtype.cpp
+++ b/test/testtype.cpp
@@ -345,6 +345,40 @@ void testTypeDefDynamic()
                   "    double value = 0\n"
                   "}\n");
     }
+    {
+        TypeDef def(TypeCode::StructA, "simple_t", {});
+
+        def += mem;
+
+        auto val = def.create();
+        shared_array<Value> arr(1);
+        arr[0] = val.allocMember().update("value", 42);
+        val = arr.freeze();
+
+        testTrue(val.valid());
+        testStrEq(std::string(SB()<<val),
+                  "struct[] [\n"
+                  "    struct \"simple_t\" {\n"
+                  "        double value = 42\n"
+                  "    }\n"
+                  "]\n");
+    }
+    {
+        TypeDef def(TypeCode::UnionA, "simple_t", {});
+
+        def += mem;
+
+        auto val = def.create();
+        shared_array<Value> arr(1);
+        arr[0] = val.allocMember().update("->value", 42);
+        val = arr.freeze();
+
+        testTrue(val.valid());
+        testStrEq(std::string(SB()<<val),
+                  "union[] [\n"
+                  "    union \"simple_t\".value        double = 42\n"
+                  "]\n");
+    }
 }
 
 void testTypeDefAppend()
@@ -520,7 +554,7 @@ void testFormat()
 
 MAIN(testtype)
 {
-    testPlan(52);
+    testPlan(56);
     testSetup();
     showSize();
     testCode();


### PR DESCRIPTION
Appending to array of struct/union should work the same as scalar of.