### PR TITLE
Fix search performance when creating a large number of channels

### DIFF
--- a/src/clientdiscover.cpp
+++ b/src/clientdiscover.cpp
@@ -93,7 +93,7 @@ std::shared_ptr<Operation> DiscoverBuilder::exec()
         if(first && ping) {
             log_debug_printf(setup, "Starting Discover%s", "\n");
 
-            context->tickSearch(true);
+            context->tickSearch(ContextImpl::SearchKind::discover);
         }
     });
 

--- a/src/clientimpl.h
+++ b/src/clientimpl.h
@@ -311,6 +311,7 @@ struct ContextImpl : public std::enable_shared_from_this<ContextImpl>
     evbase tcp_loop;
     const evevent searchRx4, searchRx6;
     const evevent searchTimer;
+    const evevent initialSearcher;
 
     // beacon handling done on UDP worker.
     // we keep a ref here as long as beaconCleaner is in use
@@ -344,6 +345,7 @@ struct ContextImpl : public std::enable_shared_from_this<ContextImpl>
     enum class SearchKind { discover, initial, check };
     void tickSearch(SearchKind kind);
     static void tickSearchS(evutil_socket_t fd, short evt, void *raw);
+    static void initialSearchS(evutil_socket_t fd, short evt, void *raw);
     void tickBeaconClean();
     static void tickBeaconCleanS(evutil_socket_t fd, short evt, void *raw);
     void cacheClean(const std::string &name, Context::cacheAction force);


### PR DESCRIPTION
When creating a large number of channels (~1000) in a short amount of time, pvxs can end up sending several search requests for each channel, without giving the IOC a reasonable amount of time to respond.   This results in search requests going missing, delaying how long it takes for all the channels to be found.  The issue is that when we send an initial search for a channel we also send search requests for channels we are waiting on.  This PR fixes this by separating the sending on initial search requests and the re-sending of failed search requests.  More details in the commit messages.

To demonstrate the issue I am using [this](https://gist.github.com/thomasives/4a0cb67b2b4253c5035cee5ea455423e) example program.  This program creates 1000 monitors to PV's provided by  the `example_ioc` from [ajgdls/EPICSPyClientPerformance.git](https://github.com/ajgdls/EPICSPyClientPerformance.git).   When investigating the performance on my machine using cashark[1], I get the following when using the master branch:
```
> tshark -r master.pcap -Y "pva.command == SEARCH" -T fields -e frame.time_relative -e pva.count | 
    awk 'BEGIN {count=0;sum=0} NR==1 {start=$1} {count+=1;sum+=$2} END {end=$1; printf "npvs=%d nframes=%d time_delta=%f s\n", sum, count, end-start}'
npvs=11931 nframes=418 time_delta=8.033979 s
```
We are, on average, sending ~12 search requests for each PV and it is taking ~8 s to finish finding them all.  With this PR I get the following in the same situation:
```
> tshark -r pr.pcap -Y "pva.command == SEARCH" -T fields -e frame.time_relative -e pva.count |
    awk 'BEGIN {count=0;sum=0} NR==1 {start=$1} {count+=1;sum+=$2} END {end=$1; printf "npvs=%d nframes=%d time_delta=%f s\n", sum, count, end-start}'
npvs=1000 nframes=282 time_delta=0.037329 s
```
With the PR, we only send a single search request for each PV and we have reduced the time it takes to finish finding all the PV's by ~250x compared to the master branch.  On my system, these pcaps are representative of what happens for each version.

@mdavidsaver Please let me know if you can think of a better way of fixing this.  I'm happy to iterate on this if needs be.

Ping @ajgdls @coretl.

[1] with a small [patch](https://gist.github.com/thomasives/362501b883edfcede29c6d49766ae4b2) to add a `pva.count` field.