### PR TITLE
Add Python 3.11 builds

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -64,6 +64,11 @@ jobs:
             python: "3.10"
             piparch: macosx_10_10_intel
 
+          - name: osx 3.11 intel
+            os: macos-latest
+            python: "3.11"
+            piparch: macosx_10_10_intel
+
           # Windows py builds
 
           ## missing Microsoft Visual C++ 9.0
@@ -99,6 +104,11 @@ jobs:
           - name: win64 3.10
             os: windows-latest
             python: "3.10"
+            piparch: win_amd64
+
+          - name: win64 3.11
+            os: windows-latest
+            python: "3.11"
             piparch: win_amd64
 
     steps:
@@ -231,6 +241,12 @@ jobs:
           - name: linux 3.10 amd64
             os: ubuntu-latest
             pyver: cp310-cp310
+            manylinux: manylinux2014
+            arch: x86_64
+
+          - name: linux 3.11 amd64
+            os: ubuntu-latest
+            pyver: cp311-cp311
             manylinux: manylinux2014
             arch: x86_64
 


### PR DESCRIPTION
This PR adds Python 3.11 to the build matrix, following the same pattern as previous releases.

Note that I didn't add a linux i686 version, as it was already missing a Python 3.10 build.
