### PR TITLE
ioc: improve long string detection

### DIFF
--- a/ioc/channel.cpp
+++ b/ioc/channel.cpp
@@ -9,8 +9,15 @@
 
 #include <string>
 
+#include <dbAccess.h>
+
 #include "channel.h"
+#include "dbentry.h"
 #include "utilpvt.h"
+
+#ifndef PVLINK_STRINGSZ
+#  define PVLINK_STRINGSZ 1024
+#endif
 
 namespace pvxs {
 namespace ioc {
@@ -20,17 +27,54 @@ namespace ioc {
  * @param name the db channel name
  */
 Channel::Channel(const char* name)
-        :std::shared_ptr<dbChannel>(std::shared_ptr<dbChannel>(dbChannelCreate(name),
+        :chan(std::shared_ptr<dbChannel>(std::shared_ptr<dbChannel>(dbChannelCreate(name),
         [](dbChannel* ch) {
             if (ch) {
                 dbChannelDelete(ch);
             }
-        }))
+        })))
 {
     if(!*this)
         throw std::runtime_error(SB()<<"Invalid PV: "<<name);
-    if (dbChannelOpen(get()))
-        throw std::invalid_argument(SB() << "Failed dbChannelOpen(\"" << dbChannelName(get()) <<"\")");
+    {
+        if( dbIsValueField(dbChannelFldDes(chan))) {
+            // info() hint only applies to VAL
+            DBEntry ent(dbChannelRecord(chan));
+            form = ent.info("Q:form", "Default");
+
+        } else {
+            form = "Default";
+        }
+
+        /* ~duplicate '$' handling logic in dbChannelCreate()
+         * when no '$' is present.
+         *
+         * situation circa Base 7.0.7
+         * At this point dbChannelCreate() has initialized chan->addr.
+         * SPC_DBADDR fields have been mangled by record support code.
+         * filter have been parsed, but not opened.
+         */
+
+        auto field_type(dbChannelFieldType(chan));
+        if(field_type==DBF_STRING && dbChannelElements(chan)==1
+                && dbChannelFieldSize(chan)>MAX_STRING_SIZE+1)
+        {
+            // scalar string field with extra capacity
+            chan->addr.no_elements = chan->addr.field_size;
+            chan->addr.field_size = 1;
+            chan->addr.field_type = DBF_CHAR;
+            chan->addr.dbr_field_type = DBR_CHAR;
+            form = "String";
+
+        } else if(field_type >= DBF_INLINK && field_type <= DBF_FWDLINK) {
+            chan->addr.no_elements = PVLINK_STRINGSZ;
+            chan->addr.field_size = 1;
+            chan->addr.dbr_field_type = DBR_CHAR;
+            form = "String";
+        }
+    }
+    if (dbChannelOpen(chan.get()))
+        throw std::invalid_argument(SB() << "Failed dbChannelOpen(\"" << dbChannelName(chan) <<"\")");
 }
 
 } // pvxs

--- a/ioc/channel.h
+++ b/ioc/channel.h
@@ -24,7 +24,21 @@ namespace ioc {
  * from string and dbChannel to make its use simpler.  It can be used wherever a dbChannel is used.
  * As a bonus when constructed with parameters it provides an already open dbChannel.
  */
-class Channel : public std::shared_ptr<dbChannel> {
+class Channel {
+    std::shared_ptr<dbChannel> chan;
+    /* Whenever chan!=nullptr, 'form' points to a string which will out-live
+     * the associated dbChannel*.  eg. either statically allocated, or an
+     * info() tag.  Value should be one of:
+     *      "Default",
+     *      "String",
+     *      "Binary",
+     *      "Decimal",
+     *      "Hex",
+     *      "Exponential",
+     *      "Engineering",
+     * (although it could be anything...)
+     */
+    const char *form = nullptr;
 public:
     Channel() = default;
     Channel(const Channel&) = default;
@@ -40,8 +54,14 @@ public:
     Channel& operator=(Channel&&) = default;
 
     operator dbChannel*() const {
-        return get();
+        return chan.get();
     }
+    dbChannel* operator->() const { return chan.get(); }
+
+    dbChannel* get() const { return chan.get(); }
+    const char* format() const { return form; }
+
+    explicit operator bool() const { return chan.operator bool(); }
 };
 
 } // pvxs

--- a/ioc/dbentry.h
+++ b/ioc/dbentry.h
@@ -50,8 +50,8 @@ public:
         return &ent;
     }
 
-    const char* info(const char *key) {
-        const char *ret = nullptr;
+    const char* info(const char *key, const char* defval=nullptr) {
+        const char *ret = defval;
         if(!dbFindInfo(&ent, key)) {
             ret = ent.pinfonode->string;
         }

--- a/ioc/groupconfigprocessor.cpp
+++ b/ioc/groupconfigprocessor.cpp
@@ -577,7 +577,7 @@ void GroupConfigProcessor::addTemplatesForDefinedFields(std::vector<Member>& gro
                                                         const GroupDefinition& groupDefinition) {
     for (auto& fieldDefinition: groupDefinition.fields) {
         auto& field = group[fieldDefinition.name];
-        dbChannel* pDbChannel = field.value;
+        auto& pDbChannel(field.value);
         switch(fieldDefinition.info.type) {
         case MappingInfo::Scalar:
             addMembersForScalarType(groupMembers, field, pDbChannel);
@@ -868,7 +868,7 @@ const char* GroupConfigProcessor::infoField(DBEntry& dbEntry, const char* key, c
  * @param pDbChannel the db channel to get information on what scalar type to create
  */
 void GroupConfigProcessor::addMembersForScalarType(std::vector<Member>& groupMembers, const Field& groupField,
-                                                   const dbChannel* pDbChannel) {
+                                                   const Channel& pDbChannel) {
     using namespace pvxs::members;
     assert(!groupField.fieldName.empty()); // Must not call with empty field name
 
@@ -887,7 +887,7 @@ void GroupConfigProcessor::addMembersForScalarType(std::vector<Member>& groupMem
  * @param pDbChannel the channel used to get the type of the leaf member
  */
 void GroupConfigProcessor::addMembersForPlainType(std::vector<Member>& groupMembers, const Field& groupField,
-                                                  const dbChannel* pDbChannel) {
+                                                  const Channel &pDbChannel) {
     assert(!groupField.fieldName.empty()); // Must not call with empty field name
 
     // Get the type for the leaf
@@ -960,7 +960,7 @@ void GroupConfigProcessor::addMembersForMetaData(std::vector<Member>& groupMembe
  * @param pDbChannel the channel to define the type definition for
  * @return the TypeDef for the channel
  */
-TypeDef GroupConfigProcessor::getTypeDefForChannel(const dbChannel* pDbChannel) {
+TypeDef GroupConfigProcessor::getTypeDefForChannel(const Channel& pDbChannel) {
     // Get the type for the leaf
     auto leafCode(IOCSource::getChannelValueType(pDbChannel, true));
     TypeDef leaf;

--- a/ioc/groupconfigprocessor.h
+++ b/ioc/groupconfigprocessor.h
@@ -65,9 +65,9 @@ private:
     static void addMembersForAnyType(std::vector<Member>& groupMembers, const Field& groupField);
     static void addMembersForMetaData(std::vector<Member>& groupMembers, const Field& groupField);
     static void addMembersForPlainType(std::vector<Member>& groupMembers, const Field& groupField,
-                                       const dbChannel* pDbChannel);
+                                       const Channel& pDbChannel);
     static void addMembersForScalarType(std::vector<Member>& groupMembers, const Field& groupField,
-                                        const dbChannel* pDbChannel);
+                                        const Channel &pDbChannel);
     static void addMembersForStructureType(std::vector<Member>& groupMembers, const Field& groupField);
     static void defineGroupTriggers(FieldDefinition& fieldDefinition, const GroupDefinition& groupDefinition,
                                     const TriggerNames& triggerNames, const std::string& groupName);
@@ -84,7 +84,7 @@ private:
     static bool yajlParseHelper(std::istream& jsonGroupDefinitionStream, yajl_handle handle);
     static void initialiseDbLocker(Group& group);
     static void initialiseTriggers(Group& group, const GroupDefinition& groupDefinition);
-    static TypeDef getTypeDefForChannel(const dbChannel* pDbChannel);
+    static TypeDef getTypeDefForChannel(const Channel &pDbChannel);
 };
 
 } // ioc

--- a/ioc/iocsource.h
+++ b/ioc/iocsource.h
@@ -45,7 +45,7 @@ class IOCSource {
 public:
     static bool enabled();
 
-    static void initialize(Value& value, const MappingInfo &info, dbChannel *chan);
+    static void initialize(Value& value, const MappingInfo &info, const Channel &chan);
 
     static void get(Value& valuePrototype,
                     const MappingInfo& info, const Value &anyType,
@@ -62,7 +62,7 @@ public:
     // Common Utils
     //////////////////////////////
     // Utility function to get the TypeCode that the given database channel is configured for
-    static TypeCode getChannelValueType(const dbChannel* pDbChannel, bool errOnLinks = false);
+    static TypeCode getChannelValueType(const Channel &pDbChannel, bool errOnLinks = false);
     static void
     setForceProcessingFlag(const Value& pvRequest, const std::shared_ptr<SecurityControlObject>& securityControlObject);
 };

--- a/ioc/singlesource.cpp
+++ b/ioc/singlesource.cpp
@@ -146,7 +146,7 @@ void onSubscribe(const std::shared_ptr<SingleSourceSubscriptionCtx>& subscriptio
  * @return a value prototype for the given channel
  */
 Value getValuePrototype(const std::shared_ptr<SingleInfo>& sinfo) {
-    dbChannel* chan(sinfo->chan);
+    auto& chan(sinfo->chan);
     short dbrType(dbChannelFinalFieldType(chan));
     auto valueType(IOCSource::getChannelValueType(chan));
 
@@ -237,7 +237,7 @@ void doneCallback(struct processNotify* notify) {
 void singleGet(const SingleInfo& info,
                std::unique_ptr<server::ExecOp>& getOperation,
                const Value& valuePrototype) {
-    dbChannel* pDbChannel(info.chan);
+    auto& pDbChannel(info.chan);
     try {
         auto returnValue = valuePrototype.cloneEmpty();
         // TODO: MappingInfo::nsecMask

--- a/test/Makefile
+++ b/test/Makefile
@@ -134,6 +134,7 @@ testqsingle_SRCS += testioc_registerRecordDeviceDriver.cpp
 testqsingle_LIBS = pvxsIoc pvxs $(EPICS_BASE_IOC_LIBS)
 TESTFILES += ../testqsingle.db
 TESTFILES += ../testqsingle64.db
+TESTFILES += ../testqsinglelsi.db
 TESTFILES += ../testioc.acf
 TESTS += testqsingle
 

--- a/test/testqsingle.db
+++ b/test/testqsingle.db
@@ -22,6 +22,11 @@ record(ai, "test:this:is:a:really:really:long:record:name") {}
 record(ai, "test:src") {
     field(INP , "test:this:is:a:really:really:long:record:name NPP")
 }
+record(waveform, "test:long:str:wf") {
+    field(FTVL, "CHAR")
+    field(NELM, "128")
+    info(Q:form, "String")
+}
 record(bo, "test:bo") {
     field(ZNAM, "Zero")
     field(ONAM, "One")

--- a/test/testqsinglelsi.db
+++ b/test/testqsinglelsi.db
@@ -1,0 +1,4 @@
+record(lsi, "test:long:str:lsi")
+{
+    field(SIZV, 128)
+}


### PR DESCRIPTION
Attempt to improve automatic handling of "long strings".  At least to handle the `$` case.

I had hoped that I could come up with a way to detect the effects of `$` or similar server side filters by inspecting the types stored in the `dbChannel` and `dbAddr` structs.  However, I've almost reached the point of giving up.  Between the mangling done in `dbChannelCreate()`, and in various `rset::cvt_dbaddr()`, I don't think this can reliably be done without extending `dbChannel`.

And there are also cases like `waveformRecord` with `FTVL=CHAR`, where `.VAL$` has never been supported because the underlying field type isn't `DBR_STRING`.

@anjohnson @coretl fyi.