### PR TITLE
Enable PVXS_QSRV_ENABLE by default

### DIFF
--- a/documentation/ioc.rst
+++ b/documentation/ioc.rst
@@ -48,9 +48,9 @@ Beginning with PVXS 1.2.0 the functionality of `QSRV <https://epics-base.github.
 is replicated in the ``pvxsIoc`` library.
 Currently this feature preview is considered **alpha** level, with missing functionality.
 In addition to linking in ``libpvxsIoc``,
-users must **opt in** at runtime by setting ``$PVXS_QSRV_ENABLE=YES`` before ``iocInit()``. ::
+users may **opt out** at runtime by setting ``$PVXS_QSRV_ENABLE=NO`` before ``iocInit()``. ::
 
-    epicsEnvSet("PVXS_QSRV_ENABLE", "YES")
+    epicsEnvSet("PVXS_QSRV_ENABLE", "NO")
     iocInit()
 
 Functionality

--- a/ioc/iocsource.cpp
+++ b/ioc/iocsource.cpp
@@ -43,7 +43,7 @@ bool IOCSource::enabled()
 
     auto e = ena.load();
     if(e==0) {
-        e = inUnitTest() ? 1 : -1; // default to disabled normally (not unittest)
+        e = 1; // default to enabled normally
 
         auto env_dis = getenv("EPICS_IOC_IGNORE_SERVERS");
         auto env_ena = getenv("PVXS_QSRV_ENABLE");


### PR DESCRIPTION
Switch the default value for PVXS_QSRV_ENABLE from "NO" to "YES". This means that "qsrv" is enabled, once compiled and linked into the IOC. It can be switched off in runtime:

epicsEnvSet("PVXS_QSRV_ENABLE", "NO")

before calling iocInit()