### PR TITLE
set TCP_NODELAY

### DIFF
--- a/src/clientconn.cpp
+++ b/src/clientconn.cpp
@@ -71,6 +71,14 @@ void Connection::startConnecting()
 
     if(bufferevent_socket_connect(bev, const_cast<sockaddr*>(&peerAddr->sa), peerAddr.size()))
         throw std::runtime_error("Unable to begin connecting");
+    {
+        auto fd(bufferevent_getfd(bev));
+        int opt = 1;
+        if(setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, (char*)&opt, sizeof(opt))<0) {
+            auto err(SOCKERRNO);
+            log_warn_printf(io, "Unable to TCP_NODELAY: %d on %d\n", err, fd);
+        }
+    }
 
     connect(bev);
 

--- a/src/serverconn.cpp
+++ b/src/serverconn.cpp
@@ -62,6 +62,13 @@ ServerConn::ServerConn(ServIface* iface, evutil_socket_t sock, struct sockaddr *
 {
     log_debug_printf(connio, "Client %s connects, RX readahead %zu TX limit %zu\n",
                      peerName.c_str(), readahead, tcp_tx_limit);
+    {
+        int opt = 1;
+        if(setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (char*)&opt, sizeof(opt))<0) {
+            auto err(SOCKERRNO);
+            log_warn_printf(connio, "Unable to TCP_NODELAY: %d on %d\n", err, sock);
+        }
+    }
 
     {
         auto cred(std::make_shared<server::ClientCredentials>());


### PR DESCRIPTION
Turns out, this flag can actually reduce latancy in some situations where Nagle interacts with delayed ack.  While I (and others) think it may be preferable to disable delayed ack., there is no portable way to do so.  So instead, do as CA and pvAccessCPP do and set `TCP_NODELAY`.

https://en.wikipedia.org/wiki/Nagle%27s_algorithm
https://en.wikipedia.org/wiki/TCP_delayed_acknowledgment
