### PR TITLE
Deserialize Size

### DIFF
--- a/src/bitmask.cpp
+++ b/src/bitmask.cpp
@@ -152,6 +152,8 @@ void from_wire(Buffer& buf, BitMask& mask)
     Size nbytes{0u};
 
     from_wire(buf, nbytes);
+    if(!buf.good() || nbytes.size > size_t(-1)/8u)
+        return;
     mask.resize(8u*nbytes.size);
 
     size_t nwords = nbytes.size / 8u;

--- a/src/dataencode.cpp
+++ b/src/dataencode.cpp
@@ -532,6 +532,9 @@ void from_wire_field(Buffer& buf, TypeStore& ctxt,  const FieldDesc* desc, const
 
                 from_wire_full(buf, ctxt, fld);
                 return;
+
+            } else { // invalid selection
+                buf.fault(__FILE__, __LINE__);
             }
         }
             break;

--- a/src/dataencode.cpp
+++ b/src/dataencode.cpp
@@ -283,7 +283,7 @@ void to_wire_field(Buffer& buf, const FieldDesc* desc, const std::shared_ptr<con
         case TypeCode::Union:
             if(!fld) {
                 // implied NULL Union member
-                to_wire(buf, Size{size_t(-1)});
+                to_wire(buf, Selector{-1});
 
             } else {
                 size_t index = 0u;
@@ -294,7 +294,7 @@ void to_wire_field(Buffer& buf, const FieldDesc* desc, const std::shared_ptr<con
                 }
                 if(index>=desc->miter.size())
                     throw std::logic_error("Union contains non-member type");
-                to_wire(buf, Size{index});
+                to_wire(buf, Selector{ev_ssize_t(index)});
                 to_wire_full(buf, fld);
             }
             return;
@@ -519,15 +519,15 @@ void from_wire_field(Buffer& buf, TypeStore& ctxt,  const FieldDesc* desc, const
         auto& fld = store->as<Value>();
         switch (desc->code.code) {
         case TypeCode::Union: {
-            Size select{};
-            from_wire(buf, select, true);
-            if(select.size==size_t(-1)) {
+            Selector select{};
+            from_wire(buf, select);
+            if(select.isnull()) {
                 fld = Value();
                 return;
 
-            } else if(select.size < desc->miter.size()) {
+            } else if(select.index() < desc->miter.size()) {
                 std::shared_ptr<const FieldDesc> stype(store->top->desc,
-                                                       &desc->members[desc->miter[select.size].second]); // alias
+                                                       &desc->members[desc->miter[select.index()].second]); // alias
                 fld = Value::Helper::build(stype, store, desc);
 
                 from_wire_full(buf, ctxt, fld);
@@ -629,15 +629,15 @@ void from_wire_field(Buffer& buf, TypeStore& ctxt,  const FieldDesc* desc, const
 
             for(auto& elem : arr) {
                 if(from_wire_as<uint8_t>(buf)!=0) { // strictly 1 or 0
-                    Size select{};
-                    from_wire(buf, select, true);
+                    Selector select{};
+                    from_wire(buf, select);
 
-                    if(select.size==size_t(-1)) {
+                    if(select.isnull()) {
                         // null element.  treated the same as 0 case (which is what actually happens)
 
-                    } else if(select.size < cdesc->miter.size()) {
+                    } else if(select.index() < cdesc->miter.size()) {
                         std::shared_ptr<const FieldDesc> stype(store->top->desc,
-                                                               &cdesc->members[cdesc->miter[select.size].second]); // alias
+                                                               &cdesc->members[cdesc->miter[select.index()].second]); // alias
                         elem = Value::Helper::build(stype, store, desc);
 
                         from_wire_full(buf, ctxt, elem);

--- a/src/pvaproto.h
+++ b/src/pvaproto.h
@@ -362,23 +362,29 @@ void from_wire(Buffer& buf, Selector& sel)
 }
 
 inline
-void to_wire(Buffer& buf, const char *s)
+void to_wire_str(Buffer& buf, const char *s, size_t cnt)
 {
-    Size len{s ? strlen(s) : 0};
+    Size len{cnt};
     to_wire(buf, len);
     if(!buf.ensure(len.size)) {
         buf.fault(__FILE__, __LINE__);
 
     } else {
-        for(size_t i=0; i<len.size; i++)
-            buf.push(s[i]);
+        memcpy(buf.save(), s, len.size);
+        buf._skip(len.size);
     }
 
 }
 
+inline
+void to_wire(Buffer& buf, const char *s)
+{
+    to_wire_str(buf, s, s ? strlen(s) : 0);
+}
+
 inline void to_wire(Buffer& buf, const std::string& s)
 {
-    to_wire(buf, s.c_str());
+    to_wire_str(buf, s.c_str(), s.size());
 }
 
 inline

--- a/src/pvaproto.h
+++ b/src/pvaproto.h
@@ -57,8 +57,10 @@ public:
     // would be nice to use GCC specific __builtin_FILE() and __builtin_LINE() here,
     // but MSVC has nothing equivalent :(
     EPICS_ALWAYS_INLINE void fault(const char *fname, int lineno) {
-        err = fname;
-        errline = lineno;
+        if(!err) {
+            err = fname;
+            errline = lineno;
+        }
     }
     EPICS_ALWAYS_INLINE bool good() const { return !err; }
     inline const char* file() const { return err ? err : "(null)"; }
@@ -272,10 +274,6 @@ void to_wire(Buffer& buf, const Size& size)
         buf.push(254);
         to_wire(buf, uint32_t(size.size));
 
-    } else if(size.size==size_t(-1)) {
-        // special "null"  used to encode empty Union
-        buf.push(255);
-
     } else {
         buf.fault(__FILE__, __LINE__);
     }
@@ -298,12 +296,69 @@ void from_wire(Buffer& buf, Size& size, bool allow_null=false)
         size.size = ls;
 
     } else if(s==255 && allow_null) {
-        // special "null"  used to encode empty Union and (sometimes) empty string
+        // special "null" which is used (maybe by pvDataJava?) for an empty string
         size.size = size_t(-1);
 
     } else {
         buf.fault(__FILE__, __LINE__);
     }
+}
+
+// Encoded the same as Size, with the added special -1 to represent a "null" value.
+// should never by < -1
+struct Selector {
+    ev_ssize_t select;
+    // should always be >= -1, but check < -1 from paranoia
+    bool isnull() const { return select<=-1; }
+    size_t index() const { return size_t(select); }
+};
+
+inline
+void to_wire(Buffer& buf, const Selector& sel)
+{
+    if(!buf.ensure(1)) {
+        buf.fault(__FILE__, __LINE__);
+
+    } else if(sel.select<=-1) { // should never be < -1, but paranoia...
+        // special "null"  used to encode empty Union
+        buf.push(255);
+
+    } else if(sel.select<254) {
+        buf.push(uint8_t(sel.select));
+
+    } else if(sel.select<=ev_ssize_t(0xffffffff)) {
+        buf.push(254);
+        to_wire(buf, uint32_t(sel.select));
+
+    } else {
+        buf.fault(__FILE__, __LINE__);
+    }
+}
+
+inline
+void from_wire(Buffer& buf, Selector& sel)
+{
+    if(!buf.ensure(1)) {
+        buf.fault(__FILE__, __LINE__);
+        return;
+    }
+    uint8_t s=buf.pop();
+    if(s<254) {
+        sel.select = s;
+
+    } else if(s==254) {
+        uint32_t ls = 0;
+        from_wire(buf, ls);
+        sel.select = ls;
+
+    } else if(s==255) {
+        // special "null" used to encode empty Union
+        sel.select = -1;
+
+    } else {
+        buf.fault(__FILE__, __LINE__);
+    }
+    // assert(sel.select>=-1);
 }
 
 inline
@@ -331,7 +386,7 @@ void from_wire(Buffer& buf, std::string& s)
 {
     Size len{0};
     from_wire(buf, len, true);
-    if(len.size==size_t(-1)) {
+    if(len.size==size_t(-1)) { // pvAccessJava will serialize null differently than ""
         s.clear();
 
     } else if(!buf.ensure(len.size)) {


### PR DESCRIPTION
The PVD notion of "size" is ambiguous in being used both for counts (number of characters in a string, or members of structure or array) and as the index of a union.  "size" has special encoding `"\xff"` provides a shorthand for `size_t(-1)` used to indicate a "null" string or union.

In C++ (PVXS and pvDataCPP) there is no "null" string, so only `"\x00"` will be emitted, and `"\x00"` and `"\xff"` decode as an empty string.  However, pvDataJava will encode a "null" as `"\xff"`.

With both C++ implementations, a resulting quirk of portability is that `"\xff"` and `"\xfe\xff\xff\xff\xff"` will both decode as `size_t(-1)` on 32-bit targets, but not on 64-bit targets.

17464a117acc9d225904c4f92cc9dc44bef2ccc0 previously avoids an issue where a bitmask "size" of `"\xff"` results in an integer overflow.

This PR goes further to add a distinct type `Selector` type for union index where the special "null" encoding is recognized.  "null" is also recognized when decoding a string.  In other cases, a "null" `Size` will now be a decode error.