### PR TITLE
JSON parsing, applied to pvxput

### DIFF
--- a/coverage.sh
+++ b/coverage.sh
@@ -45,7 +45,7 @@ OUTDIR="$PWD"/coverage
 install -d "$OUTDIR"
 
 # pre-process for each directory, correcting "file" relative to repo root
-for dir in src ioc
+for dir in src ioc tools
 do
     ( cd "$TDIR"/$dir/O.linux-* \
     && gcovr --gcov-ignore-parse-errors -v -r .. --json \
@@ -57,6 +57,7 @@ done
 gcovr \
  --add-tracefile "$TDIR"/src.json \
  --add-tracefile "$TDIR"/ioc.json \
+ --add-tracefile "$TDIR"/tools.json \
  --html --html-details -o "$OUTDIR"/coverage.html
 
 cd "$OUTDIR"

--- a/documentation/value.rst
+++ b/documentation/value.rst
@@ -179,3 +179,18 @@ of the underlying array prior to using `pvxs::shared_array::castTo`.
     :members:
 
 .. doxygenenum:: pvxs::ArrayType
+
+.. _jsonparse:
+
+JSON Parsing
+------------
+
+The `json::Parse` interface may be used to assign `Value` from a JSON string.
+
+.. code-block:: c++
+
+    #include <pvxs/json.h>
+    namespace pvxs { namespace json { ... } }
+
+.. doxygenstruct:: pvxs::json::Parse
+    :members:

--- a/src/Makefile
+++ b/src/Makefile
@@ -52,6 +52,7 @@ INC += pvxs/unittest.h
 INC += pvxs/util.h
 INC += pvxs/sharedArray.h
 INC += pvxs/data.h
+INC += pvxs/json.h
 INC += pvxs/nt.h
 INC += pvxs/netcommon.h
 INC += pvxs/server.h
@@ -72,6 +73,9 @@ LIB_SRCS += bitmask.cpp
 LIB_SRCS += type.cpp
 LIB_SRCS += data.cpp
 LIB_SRCS += datafmt.cpp
+ifdef BASE_3_15
+LIB_SRCS += json.cpp
+endif
 LIB_SRCS += pvrequest.cpp
 LIB_SRCS += dataencode.cpp
 LIB_SRCS += nt.cpp

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -1,0 +1,534 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * pvxs is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+
+#include <sstream>
+#include <list>
+#include <map>
+
+#include <pvxs/json.h>
+#include <pvxs/data.h>
+
+#include <yajl_parse.h>
+
+#include "utilpvt.h"
+
+namespace pvxs {
+namespace json {
+
+namespace {
+// undef implies API version 0
+#ifndef EPICS_YAJL_VERSION
+typedef long integer_arg;
+typedef unsigned size_arg;
+#else
+typedef long long integer_arg;
+typedef size_t size_arg;
+#endif
+
+struct JAny;
+// use std::list so that insertion does not invalidate references
+typedef std::list<std::pair<std::string, JAny> > JMap;
+typedef std::list<JAny> JList;
+
+struct JAny {
+    aligned_union<8, bool, double, int64_t, std::string, JMap, JList>::type store;
+    enum type_t {
+        Placeholder,
+        Null,
+        Bool,
+        Double,
+        Int64,
+        String,
+        List,
+        Map,
+    } type = Null;
+
+    template<typename T>
+    T& as() { return *reinterpret_cast<T*>(&store); }
+    template<typename T>
+    const T& as() const { return *reinterpret_cast<const T*>(&store); }
+
+    JAny() : store({}), type(Placeholder) {}
+    JAny(const JAny&) = delete;
+    JAny& operator=(const JAny&) = delete;
+
+    ~JAny() {
+        switch(type) {
+        case Placeholder:
+        case Null:
+        case Bool:
+        case Double:
+        case Int64:
+            break; // nothing to do for POD
+        case String:
+            as<std::string>().~basic_string();
+            break;
+        case List:
+            as<JList>().~JList();
+            break;
+        case Map:
+            as<JMap>().~JMap();
+            break;
+        }
+    }
+};
+
+constexpr size_t stkLimit = 10;
+
+struct JContext {
+    std::vector<JAny*> stk;
+    std::ostringstream msg;
+
+    void exc(const std::exception& e) noexcept {
+        try {
+            msg<<"\nError: "<<e.what(); \
+        }catch(...){
+            // exception while recording exception...  not much can be done.
+        }
+    }
+
+    JAny& setup_top() {
+        assert(!stk.empty());
+        auto& top = *stk.back();
+        if(top.type==JAny::Placeholder) {
+            return top;
+        } else if(top.type==JAny::List) {
+            auto& list = top.as<JList>();
+            list.emplace_back();
+            auto& newtop = list.back();
+            stk.push_back(&newtop);
+            return newtop;
+        } else {
+            throw std::logic_error("invalid stack state for array");
+        }
+    }
+    void consume_top() {
+        assert(!stk.empty());
+        stk.pop_back();
+    }
+};
+
+struct YHandle {
+    yajl_handle handle;
+    explicit
+    YHandle(yajl_handle handle)
+        :handle(handle)
+    {
+        if(!handle)
+            throw std::runtime_error("yajl_alloc fails");
+    }
+    ~YHandle() {
+        yajl_free(handle);
+    }
+    operator yajl_handle() { return handle; }
+};
+
+#define TRY \
+    auto ctx = static_cast<JContext*>(raw); \
+    try
+
+#define CATCH() \
+    catch(std::exception& e){ \
+        ctx->exc(e); \
+        return 0; \
+    }
+
+int jvalue_null(void * raw) noexcept {
+    TRY {
+        auto& top = ctx->setup_top();
+        top.type = JAny::Null;
+        ctx->consume_top();
+
+        return 1;
+    }CATCH()
+}
+
+int jvalue_boolean(void * raw, int val) noexcept {
+    TRY {
+        auto& top = ctx->setup_top();
+        top.type = JAny::Bool;
+        top.as<bool>() = val;
+        ctx->consume_top();
+
+        return 1;
+    }CATCH()
+}
+
+int jvalue_integer(void * raw, integer_arg val) noexcept {
+    TRY {
+        auto& top = ctx->setup_top();
+        top.type = JAny::Int64;
+        top.as<int64_t>() = val;
+        ctx->consume_top();
+
+        return 1;
+    }CATCH()
+}
+
+int jvalue_real(void * raw, double val) noexcept {
+    TRY {
+        auto& top = ctx->setup_top();
+        top.type = JAny::Double;
+        top.as<double>() = val;
+        ctx->consume_top();
+
+        return 1;
+    }CATCH()
+}
+
+int jvalue_string(void * raw, const unsigned char * val, size_arg len) {
+    TRY {
+        auto& top = ctx->setup_top();
+        new (&top.store) std::string((const char*)val, len);
+        top.type = JAny::String;
+        ctx->consume_top();
+
+        return 1;
+    }CATCH()
+}
+
+int jvalue_start_map(void * raw) noexcept {
+    TRY {
+        if(ctx->stk.size() >= stkLimit)
+            throw std::runtime_error("JSON structure too deep!");
+
+        auto& top = ctx->setup_top();
+        new (&top.store) JMap();
+        top.type = JAny::Map;
+
+        return 1;
+    }CATCH()
+}
+
+int jvalue_map_key(void * raw, const unsigned char * val, size_arg len) {
+    TRY {
+        assert(!ctx->stk.empty());
+        auto& top = *ctx->stk.back();
+        assert(top.type==JAny::Map);
+
+        auto& map = top.as<JMap>();
+        map.emplace_back(std::piecewise_construct,
+                         std::forward_as_tuple((const char*)val, len),
+                         std::forward_as_tuple());
+        ctx->stk.push_back(&map.back().second);
+
+        return 1;
+    }CATCH()
+}
+
+int jvalue_end_map(void * raw) noexcept {
+    TRY {
+        assert(!ctx->stk.empty());
+        const auto& top = ctx->stk.back();
+        assert(top->type==JAny::Map);
+
+        ctx->consume_top();
+
+        return 1;
+    }CATCH()
+}
+
+int jvalue_start_array(void * raw) noexcept {
+    TRY {
+        if(ctx->stk.size() >= stkLimit)
+            throw std::runtime_error("JSON structure too deep!");
+
+        auto& top = ctx->stk.back();
+        assert(top->type==JAny::Placeholder);
+        new (&top->store) JList();
+        top->type = JAny::List;
+
+        return 1;
+    }CATCH()
+}
+
+int jvalue_end_array(void * raw) noexcept {
+    TRY {
+        assert(!ctx->stk.empty());
+        const auto& top = ctx->stk.back();
+        assert(top->type==JAny::List);
+
+        ctx->consume_top();
+
+        return 1;
+    }CATCH()
+}
+
+const yajl_callbacks jvalue_cbs = {
+    jvalue_null,
+    jvalue_boolean,
+    jvalue_integer,
+    jvalue_real,
+    nullptr,
+    jvalue_string,
+    jvalue_start_map,
+    jvalue_map_key,
+    jvalue_end_map,
+    jvalue_start_array,
+    jvalue_end_array,
+};
+
+static
+TypeDef type_from_ast(const JAny& src) {
+    switch(src.type) {
+    case JAny::Placeholder:
+        throw std::logic_error("placeholder in JSON AST");
+    case JAny::Null:
+        return TypeDef(TypeCode::Any);
+    case JAny::Bool:
+        return TypeDef(TypeCode::Bool);
+    case JAny::Double:
+        return TypeDef(TypeCode::Float64);
+    case JAny::Int64:
+        return TypeDef(TypeCode::Int64);
+    case JAny::String:
+        return TypeDef(TypeCode::String);
+    case JAny::Map: {
+        std::vector<Member> members;
+        auto& map = src.as<JMap>();
+        for(auto& pair : map) {
+            members.emplace_back(type_from_ast(pair.second).as(pair.first));
+        }
+        // TODO: infer struct_t name?
+        // TODO: infer Union?
+        return TypeDef(TypeCode::Struct, std::string(), members);
+    }
+    case JAny::List: {
+        const auto& list = src.as<JList>();
+        if(list.empty())
+            return TypeDef(TypeCode::Float64A);
+        TypeCode ltype = TypeCode::Null;
+        for(const auto& item : list) {
+            TypeCode itype;
+            switch(item.type) {
+            case JAny::Placeholder:
+                throw std::logic_error("placeholder in JSON AST");
+            case JAny::Null:
+                throw std::runtime_error("Unable to infer list with null");
+            case JAny::Int64:
+                itype = TypeCode::Int64A;
+                break;
+            case JAny::Double:
+                itype = TypeCode::Float64A;
+                break;
+            case JAny::Bool:
+                itype = TypeCode::BoolA;
+                break;
+            case JAny::String:
+                itype = TypeCode::StringA;
+                break;
+            case JAny::List:
+            case JAny::Map:
+                throw std::runtime_error("Infer array from JSON list of list/map not yet implemented");
+            }
+
+            if(ltype==TypeCode::Null) { // first item
+                ltype = itype;
+            } else if(ltype==itype) {
+                // same, no-op
+            } else if(ltype.kind()==Kind::Real && (itype.kind()==Kind::Integer || ltype.kind()==Kind::Bool)) {
+                // silently promote value
+            } else if(itype.kind()==Kind::Real && (ltype.kind()==Kind::Integer || ltype.kind()==Kind::Bool)) {
+                // silently promote list type int/bool to real
+                ltype = itype;
+            } else if(ltype.kind()==Kind::Integer && itype.kind()==Kind::Bool) {
+                // silently promote value
+            } else if(itype.kind()==Kind::Integer && ltype.kind()==Kind::Bool) {
+                // silently promote bool to int
+                ltype = itype;
+            } else {
+                throw std::runtime_error(SB()<<"Unable to infer array from JSON list containing both "<<ltype<<" and "<<itype);
+            }
+        }
+
+        return TypeDef(ltype);
+    }
+    }
+    throw std::logic_error("Uninferable type");
+}
+
+Value infer_from_ast(const JAny& src) {
+    return type_from_ast(src).create();
+}
+
+void apply_ast(Value& dest, const JAny& src)
+{
+    switch(src.type) {
+    case JAny::Placeholder:
+        throw std::logic_error("placeholder in JSON AST");
+    case JAny::Null:
+        dest = unselect;
+        break;
+    case JAny::Bool:
+        dest.from(src.as<bool>());
+        break;
+    case JAny::Double:
+        dest.from(src.as<double>());
+        break;
+    case JAny::Int64:
+        dest.from(src.as<int64_t>());
+        break;
+    case JAny::String:
+        dest.from(src.as<std::string>());
+        break;
+    case JAny::Map: {
+        auto& map = src.as<JMap>();
+        for(auto& pair : map) {
+            auto node(dest.lookup(pair.first));
+            apply_ast(node, pair.second);
+        }
+    }
+        break;
+    case JAny::List: {
+        auto& list = src.as<JList>();
+        auto dtype(dest.type());
+
+        if(dtype==TypeCode::StructA || dtype==TypeCode::UnionA) {
+            shared_array<Value> elems(list.size());
+            size_t i=0;
+            for(auto& elem : list) {
+                if(elem.type!=JAny::Null) {
+                    auto& eval = elems[i] = dest.allocMember();
+                    apply_ast(eval, elem);
+                }
+                i++;
+            }
+            dest.from(elems.freeze());
+
+        } else if(dtype==TypeCode::AnyA) {
+            shared_array<Value> elems(list.size());
+            size_t i=0;
+            for(auto& elem : list) {
+                if(elem.type!=JAny::Null) {
+                    auto& eval = elems[i] = infer_from_ast(elem);
+                    apply_ast(eval, elem);
+                }
+                i++;
+            }
+            dest.from(elems.freeze());
+
+        } else { // array of scalar type
+            auto arr(allocArray(dtype.arrayType(), list.size()));
+            auto etype(arr.original_type());
+            auto esize(elementSize(etype));
+            auto cur(arr.data());
+
+            for(auto& elem : list) {
+                ArrayType stype;
+                switch(elem.type) {
+                case JAny::Bool: stype = ArrayType::Bool; break;
+                case JAny::Double: stype = ArrayType::Float64; break;
+                case JAny::Int64: stype = ArrayType::Int64; break;
+                case JAny::String: stype = ArrayType::String; break;
+                default:
+                    throw std::runtime_error(SB()<<"Can't assign "<<etype<<" with compound value");
+                }
+                detail::convertArr(etype, cur, stype, &elem.store, 1);
+
+                cur = esize + (char*)cur;
+            }
+
+            dest.from(arr.freeze());
+        }
+    }
+        break;
+    }
+}
+
+void parse_into_ast(const char* cur, size_t len, JAny& top)
+{
+    // ignore leading space
+    for(; len && isspace(*cur); len--, cur++) {}
+
+    // PoS YAJL does not parse bare numbers correctly, so handle as a special case...
+    if(cur[0]!='"' && cur[0]!='{' && cur[0]!='[') {
+        std::string num(cur, len);
+
+        if(num.find_first_of('.')!=num.npos) { // float
+            top.type = JAny::Double;
+            top.as<double>() = parseTo<double>(num);
+        } else { // integer
+            top.type = JAny::Int64;
+            top.as<int64_t>() = parseTo<int64_t>(num);
+        }
+
+        return;
+    }
+
+    // parse into AST
+    JContext ctx;
+    ctx.stk.push_back(&top);
+
+#ifndef EPICS_YAJL_VERSION
+    yajl_parser_config conf;
+    memset(&conf, 0, sizeof(conf));
+    conf.allowComments = 1;
+    conf.checkUTF8 = 1;
+    YHandle handle(yajl_alloc(&jvalue_cbs, &conf, NULL, &ctx));
+#else
+    YHandle handle(yajl_alloc(&jvalue_cbs, NULL, &ctx));
+
+    yajl_config(handle, yajl_allow_comments, 1);
+#endif
+
+    auto sts(yajl_parse(handle, (const unsigned char*)cur, len));
+    auto consumed(yajl_get_bytes_consumed(handle));
+
+    switch(sts) {
+    case yajl_status_ok:
+        for(; consumed < len; consumed++) {
+            if(!isspace(cur[consumed]))
+                throw std::runtime_error("Trailing junk after JSON");
+        }
+        // success
+        break;
+    case yajl_status_client_canceled:
+        throw std::runtime_error(ctx.msg.str());
+#ifndef EPICS_YAJL_VERSION
+    case yajl_status_insufficient_data:
+        throw std::runtime_error("JSON incomplete");
+        break;
+#endif
+    case yajl_status_error: {
+        auto raw(yajl_get_error(handle, 1, (const unsigned char*)cur, len));
+        try {
+            ctx.msg<<"\nJSON Syntax error: "<<raw;
+        } catch(...) {
+            // error while reporting error.  not much can be done...
+        }
+        yajl_free_error(handle, raw);
+        throw std::runtime_error(ctx.msg.str());
+    }
+    }
+
+    if(!ctx.stk.empty()) {
+#ifdef EPICS_YAJL_VERSION
+        throw std::runtime_error("JSON incomplete");
+#else
+        throw std::logic_error("json parse stack unclean");
+#endif
+    }
+}
+
+} // namespace
+
+void Parse::into(Value& v) const
+{
+    JAny top;
+    parse_into_ast(base, count, top);
+    apply_ast(v, top);
+}
+
+Value Parse::as() const
+{
+    JAny top;
+    parse_into_ast(base, count, top);
+    auto ret(infer_from_ast(top));
+    apply_ast(ret, top);
+    return ret;
+}
+
+}} // namespace pvxs::json

--- a/src/pvxs/json.h
+++ b/src/pvxs/json.h
@@ -14,6 +14,10 @@
 
 #include <pvxs/version.h>
 
+#if EPICS_VERSION_INT < VERSION_INT(3, 15, 0, 0)
+#  error JSON support requires Base 3.15 or later
+#endif
+
 #ifdef PVXS_EXPERT_API_ENABLED
 
 namespace pvxs {

--- a/src/pvxs/json.h
+++ b/src/pvxs/json.h
@@ -1,0 +1,115 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * pvxs is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+
+#ifndef PVXS_JSON_H
+#define PVXS_JSON_H
+
+#include <string>
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <pvxs/version.h>
+
+#ifdef PVXS_EXPERT_API_ENABLED
+
+namespace pvxs {
+class Value;
+
+namespace json {
+
+/** Parse JSON string
+ *
+ *  String must be complete JSON value, object, or sequence.
+ *  Leading and trailing whitespace is allowed and ignored.
+ *
+ *  A character array must remain valid and unmodified for
+ *  the lifetime of the Parse object referencing it.
+ *
+ *  @section jsonassign Assignment
+ *
+ *  When assigning JSON to Value, Value::from() is used.
+ *  So the same range of implicit type conversions are attempted.
+ *  eg.
+ *
+ *  @code
+ *  Value top = TypeDef(TypeCode::Int32).build();
+ *
+ *  json::Parse("42").into(top);
+ *  // equivalent to
+ *  top.from(42);
+ *
+ *  and
+ *
+ *  json::Parse("\"42\"").into(top);
+ *  // equivalent to
+ *  top.from("42");
+ *  @endcode
+ *
+ *  @since UNRELEASED
+ */
+struct Parse {
+private:
+    const char* base;
+    size_t count;
+public:
+
+    //! Parse from Nil terminated string.
+    inline
+    Parse(const char *s) noexcept
+        :base(s)
+        ,count(s ? strlen(s) : 0u)
+    {}
+    //! Parse Character array without terminating Nil.
+    inline
+    constexpr Parse(const char *s, size_t c) noexcept
+        :base(s)
+        ,count(c)
+    {}
+    //! Parse from String
+    inline
+    Parse(const std::string& s) noexcept
+        :base(s.c_str())
+        ,count(s.size())
+    {}
+
+    /** Assign previously created Value from parsed string.
+     *
+     *  Provided Value may be modified on error.
+     *
+     *  @pre v.valid()
+     *  @throws std::runtime_error on Parse error
+     */
+    PVXS_API
+    void into(Value& v) const;
+
+    /** Infer type from JSON value
+     *
+     *  Attempts to interpret the provided JSON into one of the supported Value types.
+     *  The returned Value will be assigned from the parsed JSON.
+     *
+     *  @throws std::runtime_error on Parse or type inference error
+     *
+     *  Not all types may be inferred.  The currently supported inferences are:
+     *
+     *  - null -> TypeCode::Any
+     *  - Boolean -> TypeCode::Bool
+     *  - String -> TypeCode::String
+     *  - Number -> TypeCode::Int64 or TypeCode::Float64 (if value appears to be real)
+     *  - Mapping -> Struct
+     *  - Sequence -> Array depending on element types.
+     *    Currently only BoolA, Int64A, Float64A, or StringA may be inferred.
+     */
+    PVXS_API
+    Value as() const;
+};
+
+} // namespace json
+} // namespace pvxs
+
+#endif // PVXS_EXPERT_API_ENABLED
+
+#endif // PVXS_JSON_H

--- a/test/Makefile
+++ b/test/Makefile
@@ -51,6 +51,12 @@ TESTPROD_HOST += testdata
 testdata_SRCS += testdata.cpp
 TESTS += testdata
 
+ifdef BASE_3_15
+TESTPROD_HOST += testjson
+testjson_SRCS += testjson.cpp
+TESTS += testjson
+endif
+
 TESTPROD_HOST += testnt
 testnt_SRCS += testnt.cpp
 TESTS += testnt

--- a/test/testjson.cpp
+++ b/test/testjson.cpp
@@ -1,0 +1,330 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * pvxs is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+
+#include <stdexcept>
+
+#include <testMain.h>
+
+#include <dbDefs.h>
+#include <epicsUnitTest.h>
+
+#define PVXS_ENABLE_EXPERT_API
+
+#include <pvxs/unittest.h>
+#include <pvxs/json.h>
+#include <pvxs/nt.h>
+#include <pvxs/data.h>
+
+#include "utilpvt.h"
+
+using namespace pvxs;
+namespace  {
+
+void testBad()
+{
+    testDiag("%s", __func__);
+
+    static const char* inputs[] = {
+        "",
+        " 14 x",
+        " {",
+        " {} extra",
+        R"({"value":{"A":[1,2], "B":"[1.5, 2.5]}}")",
+    };
+
+    for(size_t i=0; i<NELEMENTS(inputs); i++) {
+        auto inp = inputs[i];
+        testThrows<std::runtime_error>([inp](){
+            Value empty;
+            json::Parse(inp).into(empty);
+        })<<" Expected error from "<<escape(inp);
+    }
+}
+
+void testScalar()
+{
+    testDiag("%s", __func__);
+
+    {
+        Value val(TypeDef(TypeCode::String).create());
+        json::Parse(R"( "hello" )").into(val);
+        testEq(val.as<std::string>(), "hello");
+    }
+
+    {
+        Value val(TypeDef(TypeCode::Int16).create());
+        json::Parse("42").into(val);
+        testEq(val.as<int16_t>(), 42);
+    }
+
+    {
+        Value val(TypeDef(TypeCode::Int64).create());
+        json::Parse(" -42  ").into(val);
+        testEq(val.as<int16_t>(), -42);
+    }
+
+    {
+        Value val(TypeDef(TypeCode::Float64).create());
+        json::Parse(" -42.5 ").into(val);
+        testEq(val.as<double>(), -42.5);
+    }
+}
+
+void testStruct()
+{
+    testDiag("%s", __func__);
+
+    {
+        Value top(nt::NTScalar{TypeCode::UInt16, true}.create());
+        json::Parse(R"( {"value":43, "alarm":{"severity":1, "status":2, "message":"hello"}, "display":{}} )").into(top);
+        testEq(top["value"].as<int16_t>(), 43);
+        testEq(top["alarm.severity"].as<int16_t>(), 1);
+        testEq(top["alarm.status"].as<int16_t>(), 2);
+        testEq(top["alarm.message"].as<std::string>(), "hello");
+    }
+}
+
+void testArrayOfScalar()
+{
+    testDiag("%s", __func__);
+
+    {
+        Value val(TypeDef(TypeCode::Int32A).create());
+        json::Parse(R"( [1, 2,3 ] )").into(val);
+        shared_array<const int32_t> expect({1, 2, 3});
+        testArrEq(val.as<shared_array<const int32_t>>(), expect);
+    }
+
+    {
+        Value val(TypeDef(TypeCode::Int32A).create());
+        json::Parse(R"( [1, 2.5,3 ] )").into(val);
+        shared_array<const int32_t> expect({1, 2, 3});
+        testArrEq(val.as<shared_array<const int32_t>>(), expect);
+    }
+
+    {
+        Value val(TypeDef(TypeCode::Float64A).create());
+        json::Parse(R"( [1.5, 2,3 ] )").into(val);
+        shared_array<const double> expect({1.5, 2.0, 3.0});
+        testArrEq(val.as<shared_array<const double>>(), expect);
+    }
+
+    {
+        Value val(TypeDef(TypeCode::StringA).create());
+        json::Parse(R"( ["1", "hello", "world" ] )").into(val);
+        shared_array<const std::string> expect({"1", "hello", "world"});
+        testArrEq(val.as<shared_array<const std::string>>(), expect);
+    }
+}
+
+void testStructArray()
+{
+    using namespace pvxs::members;
+
+    testDiag("%s", __func__);
+
+    {
+        Value val(TypeDef(TypeCode::StructA, {
+                              Int32("ival"),
+                              String("sval"),
+                              Int32A("aval"),
+                          }).create());
+        json::Parse("["
+                    "{\"ival\":1, \"sval\":\"hello\"},"
+                    "null,"
+                    "{\"aval\": [4,5,6]}"
+                    "]").into(val);
+        testStrEq(std::string(SB()<<val),
+                  "struct[] = {3}[\n"
+                  "    struct {\n"
+                  "        int32_t ival = 1\n"
+                  "        string sval = \"hello\"\n"
+                  "        int32_t[] aval = {?}[]\n"
+                  "    }\n"
+                  "    null\n"
+                  "    struct {\n"
+                  "        int32_t ival = 0\n"
+                  "        string sval = \"\"\n"
+                  "        int32_t[] aval = {3}[4, 5, 6]\n"
+                  "    }\n"
+                  "]\n");
+    }
+}
+
+void testUnionArray()
+{
+    using namespace pvxs::members;
+
+    testDiag("%s", __func__);
+
+    {
+        Value val(TypeDef(TypeCode::UnionA, {
+                              Bool("bval"),
+                              Int32("ival"),
+                              String("sval"),
+                              Int32A("aval"),
+                          }).create());
+        json::Parse("["
+                    "{\"ival\":1},"
+                    "true,"
+                    "null,"
+                    "{\"aval\": [4,5,6]}"
+                    "]").into(val);
+        testStrEq(std::string(SB()<<val),
+                  "union[] = {4}[\n"
+                  "    union.ival int32_t = 1\n"
+                  "    union.bval bool = true\n"
+                  "    null\n"
+                  "    union.aval int32_t[] = {3}[4, 5, 6]\n"
+                  "]\n");
+    }
+}
+
+void testAnyA()
+{
+    testDiag("%s", __func__);
+
+    auto val(TypeDef(TypeCode::AnyA).create());
+
+    json::Parse("["
+                "true,"
+                "{\"aval\": [4,5,6]}"
+                "]").into(val);
+    testStrEq(std::string(SB()<<val),
+              "any[] = {2}[\n"
+              "    bool = true\n"
+              "    struct {\n"
+              "        int64_t[] aval = {3}[4, 5, 6]\n"
+              "    }\n"
+              "]\n");
+}
+
+void testNTTable()
+{
+    auto val(nt::NTTable{}
+             .add_column(TypeCode::Float64, "A")
+             .add_column(TypeCode::Float64, "B")
+             .create());
+
+    json::Parse(R"({"value":{"A":[1,2], "B":[1.5, 2.5]}})").into(val);
+    testStrEq(std::string(SB()<<val),
+              "struct \"epics:nt/NTTable:1.0\" {\n"
+              "    string[] labels = {2}[\"A\", \"B\"]\n"
+              "    struct {\n"
+              "        double[] A = {2}[1, 2]\n"
+              "        double[] B = {2}[1.5, 2.5]\n"
+              "    } value\n"
+              "    string descriptor = \"\"\n"
+              "    struct \"alarm_t\" {\n"
+              "        int32_t severity = 0\n"
+              "        int32_t status = 0\n"
+              "        string message = \"\"\n"
+              "    } alarm\n"
+              "    struct \"time_t\" {\n"
+              "        int64_t secondsPastEpoch = 0\n"
+              "        int32_t nanoseconds = 0\n"
+              "        int32_t userTag = 0\n"
+              "    } timeStamp\n"
+              "}\n");
+}
+
+void testInfer()
+{
+    testDiag("%s", __func__);
+
+    {
+        auto val(json::Parse(R"(42)").as());
+        testEq(val.type(), TypeCode::Int64);
+        testEq(val.as<int32_t>(), 42);
+    }
+    {
+        auto val(json::Parse(R"(42.5)").as());
+        testEq(val.type(), TypeCode::Float64);
+        testEq(val.as<double>(), 42.5);
+    }
+    {
+        auto val(json::Parse(R"("foo")").as());
+        testEq(val.type(), TypeCode::String);
+        testEq(val.as<std::string>(), "foo");
+    }
+    {
+       auto val(json::Parse(R"([])").as());
+       testEq(val.type(), TypeCode::Float64A);
+       testEq(val.as<shared_array<const int64_t>>().size(), 0u);
+    }
+    {
+       auto val(json::Parse(R"([1,2])").as());
+       testEq(val.type(), TypeCode::Int64A);
+       shared_array<const int64_t> expect({1,2});
+       testArrEq(val.as<shared_array<const int64_t>>(), expect);
+    }
+    {
+       auto val(json::Parse(R"([1,2.0])").as());
+       testEq(val.type(), TypeCode::Float64A);
+       shared_array<const double> expect({1,2});
+       testArrEq(val.as<shared_array<const double>>(), expect);
+    }
+    {
+       auto val(json::Parse(R"([2.0,1])").as());
+       testEq(val.type(), TypeCode::Float64A);
+       shared_array<const double> expect({2,1});
+       testArrEq(val.as<shared_array<const double>>(), expect);
+    }
+    {
+        auto val(json::Parse(R"([1,false])").as());
+        testEq(val.type(), TypeCode::Int64A);
+        shared_array<const int64_t> expect({1,0});
+        testArrEq(val.as<shared_array<const int64_t>>(), expect);
+    }
+    {
+        auto val(json::Parse(R"([false,1])").as());
+        testEq(val.type(), TypeCode::Int64A);
+        shared_array<const int64_t> expect({0,1});
+        testArrEq(val.as<shared_array<const int64_t>>(), expect);
+    }
+    {
+        auto val(json::Parse(R"([true, false])").as());
+        testEq(val.type(), TypeCode::BoolA);
+        shared_array<const bool> expect({true, false});
+        testArrEq(val.as<shared_array<const bool>>(), expect);
+    }
+    {
+        auto val(json::Parse(R"(["hello", "world"])").as());
+        testEq(val.type(), TypeCode::StringA);
+        shared_array<const std::string> expect({"hello", "world"});
+        testArrEq(val.as<shared_array<const std::string>>(), expect);
+    }
+    {
+       auto val(json::Parse(R"({"foo":1, "bar":{"a":"blah", "b":null, "c":false}})").as());
+       testStrEq((SB()<<val).str(),
+                 "struct {\n"
+                 "    int64_t foo = 1\n"
+                 "    struct {\n"
+                 "        string a = \"blah\"\n"
+                 "        any b null\n"
+                 "        bool c = false\n"
+                 "    } bar\n"
+                 "}\n");
+    }
+}
+
+} // namespace
+
+MAIN(testjson)
+{
+    testPlan(44);
+    testBad();
+    testScalar();
+    testStruct();
+    testArrayOfScalar();
+    testStructArray();
+    testUnionArray();
+    testAnyA();
+    testNTTable();
+    testInfer();
+    cleanup_for_valgrind();
+    return testDone();
+}

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -12,6 +12,8 @@ USR_CPPFLAGS += -I$(TOP)/src
 
 PROD_LIBS += pvxs Com
 
+PROD_SRCS += cliutil.cpp
+
 PROD += pvxvct
 pvxvct_SRCS += pvxvct.cpp
 
@@ -35,6 +37,18 @@ pvxlist_SRCS += list.cpp
 
 PROD += pvxmshim
 pvxmshim_SRCS += mshim.cpp
+
+# tests of CLI tools
+
+TESTPROD_HOST += testcliutil
+testcliutil_SRCS += testcliutil.cpp
+TESTS += testcliutil
+
+TESTPROD_HOST += testxput
+testxput_SRCS += testxput.cpp
+TESTS += testxput
+
+TESTSCRIPTS_HOST += $(TESTS:%=%.t)
 
 endif # BASE_3_15
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -5,6 +5,8 @@ include $(TOP)/configure/CONFIG
 #  ADD MACRO DEFINITIONS AFTER THIS LINE
 #=============================
 
+ifdef BASE_3_15
+
 # access to private headers
 USR_CPPFLAGS += -I$(TOP)/src
 
@@ -33,6 +35,8 @@ pvxlist_SRCS += list.cpp
 
 PROD += pvxmshim
 pvxmshim_SRCS += mshim.cpp
+
+endif # BASE_3_15
 
 #===========================
 

--- a/tools/cliutil.cpp
+++ b/tools/cliutil.cpp
@@ -1,0 +1,83 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * pvxs is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+
+#include "cliutil.h"
+
+namespace pvxs {
+
+bool operator==(const ArgVal& rhs, const ArgVal& lhs) {
+    return rhs.defined==lhs.defined && rhs.value==lhs.value;
+}
+
+GetOpt::GetOpt(int argc, char *argv[], const char *spec)
+    :argv0("<program name>")
+{
+    if(argc>=1)
+        argv0 = argv[0];
+
+    bool allpos = false; // after "--", treat all remaining as positional
+    for(int i=1; i<argc; i++) {
+        const char * arg = argv[i];
+        if(!allpos && arg[0]=='-') {
+            arg++;
+
+            if(arg[0]=='-') {
+                if(arg[1]=='\0') { // "--"
+                    allpos = true;
+                    continue;
+                }
+                // "--..." not supported
+                arguments.emplace_back(-1, argv[i]);
+                continue;
+            }
+            // process as short args
+
+            for(; *arg; arg++) {
+                for(auto s=spec; *s; s++) {
+                    if(*s==*arg) { // match
+                        if(s[1]==':') { // need arg value
+                            if(arg[1]=='\0') { // "-a", "value"
+                                if(i+1==argc) {
+                                    // oops. no value
+                                    arguments.emplace_back('?', nullptr);
+                                    return;
+                                }
+                                arguments.emplace_back(*arg, argv[i+1]);
+                                i++;
+
+                            } else {
+                                // "-avalue"
+                                arguments.emplace_back(*arg, &arg[1]);
+                            }
+                            goto nextarg;
+
+                        } else { // flag
+                            arguments.emplace_back(*s, nullptr);
+                            // continue scanning for more flags.  eg. "-vv"
+                            goto nextchar;
+                        }
+                    } else {
+                        if(s[1]==':')
+                            s++;
+                    }
+                }
+                // unrecognized
+                arguments.emplace_back(-1, nullptr);
+                break;
+nextchar:
+                (void)0;  // need a statement after label...
+            }
+nextarg:
+            (void)0;
+
+        } else {
+            positional.push_back(arg);
+        }
+        success = true;
+    }
+}
+
+} // namespace pvxs

--- a/tools/cliutil.h
+++ b/tools/cliutil.h
@@ -1,0 +1,58 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * pvxs is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+
+#ifndef CLIUTIL_H
+#define CLIUTIL_H
+
+#include <vector>
+#include <string>
+#include <stdexcept>
+#include <map> // for std::pair
+
+#include <utilpvt.h>
+
+namespace pvxs {
+
+struct ArgVal {
+    std::string value;
+    bool defined = false;
+
+    ArgVal() = default;
+    ArgVal(std::nullptr_t) {}
+    ArgVal(const std::string& value) :value(value), defined(true) {}
+    ArgVal(const char* value) :value(value), defined(true) {}
+
+    inline explicit
+    operator bool() const { return defined; }
+
+    inline
+    const std::string& operator*() const {
+        if(defined)
+            return value;
+        throw std::logic_error("Undefined argument value");
+    }
+
+    template<typename V>
+    inline
+    V as() const {
+        return parseTo<V>(**this);
+    }
+};
+
+bool operator==(const ArgVal& rhs, const ArgVal& lhs);
+
+struct GetOpt {
+    GetOpt(int argc, char *argv[], const char *spec);
+
+    const char *argv0;
+    std::vector<std::string> positional;
+    std::vector<std::pair<char, ArgVal>> arguments;
+    bool success = false;
+};
+
+} // namespace pvxs
+
+#endif // CLIUTIL_H

--- a/tools/put.cpp
+++ b/tools/put.cpp
@@ -12,8 +12,11 @@
 #include <epicsGetopt.h>
 #include <epicsThread.h>
 
+#define PVXS_ENABLE_EXPERT_API
+
 #include <pvxs/client.h>
 #include <pvxs/log.h>
+#include <pvxs/json.h>
 #include "utilpvt.h"
 #include "evhelper.h"
 
@@ -85,9 +88,10 @@ int main(int argc, char *argv[])
 
         if(argc-optind==1 && std::string(argv[optind]).find_first_of('=')==std::string::npos) {
             // only one field assignment, and field name omitted.
-            // implies .value
+            // if JSON map, treat as entire struct.  Others imply .value
 
-            values["value"] = argv[optind];
+            auto sval(argv[optind]);
+            values[sval[0]=='{' ? "" : "value"] = sval;
 
         } else {
             for(auto n : range(optind, argc)) {
@@ -120,9 +124,18 @@ int main(int argc, char *argv[])
                     val.unmark(false, true);
                     for(auto& pair : values) {
                         try{
-                            val[pair.first] = pair.second;
-                        }catch(NoConvert& e){
-                            throw std::runtime_error(SB()<<"Unable to assign "<<pair.first<<" from \""<<escape(pair.second)<<"\"");
+                            auto fld(val);
+                            if(!pair.first.empty())
+                                fld = val.lookup(pair.first);
+                            auto& sv(pair.second);
+                            if(!sv.empty() && (sv[0]=='{' || sv[0]=='[' || sv[0]=='"'))
+                                json::Parse(pair.second).into(fld);
+                            else
+                                fld.from(sv);
+                        }catch(std::exception& e){
+                            throw std::runtime_error(SB()<<"Unable to assign "<<pair.first
+                                                     <<" from \""<<escape(pair.second)<<"\""
+                                                     <<" : "<<e.what());
                         }
                     }
                     if(verbose) {

--- a/tools/put.cpp
+++ b/tools/put.cpp
@@ -9,7 +9,6 @@
 #include <atomic>
 
 #include <epicsVersion.h>
-#include <epicsGetopt.h>
 #include <epicsThread.h>
 
 #define PVXS_ENABLE_EXPERT_API
@@ -19,6 +18,11 @@
 #include <pvxs/json.h>
 #include "utilpvt.h"
 #include "evhelper.h"
+#include "cliutil.h"
+
+#ifndef REALMAIN
+#  define REALMAIN main
+#endif
 
 using namespace pvxs;
 
@@ -37,9 +41,9 @@ void usage(const char* argv0)
                ;
 }
 
-}
+} // namespace
 
-int main(int argc, char *argv[])
+int REALMAIN(int argc, char *argv[])
 {
     try {
         logger_config_env(); // from $PVXS_LOG
@@ -47,55 +51,53 @@ int main(int argc, char *argv[])
         bool verbose = false;
         std::string request;
 
-        {
-            int opt;
-            while ((opt = getopt(argc, argv, "hvVdw:r:")) != -1) {
-                switch(opt) {
-                case 'h':
-                    usage(argv[0]);
-                    return 0;
-                case 'V':
-                    std::cout<<pvxs::version_information;
-                    return 0;
-                case 'v':
-                    verbose = true;
-                    break;
-                case 'd':
-                    logger_level_set("pvxs.*", Level::Debug);
-                    break;
-                case 'w':
-                    timeout = parseTo<double>(optarg);
-                    break;
-                case 'r':
-                    request = optarg;
-                    break;
-                default:
-                    usage(argv[0]);
-                    std::cerr<<"\nUnknown argument: "<<char(opt)<<std::endl;
-                    return 1;
-                }
+        GetOpt opts(argc, argv, "hvVdw:r:");
+        for(auto& pair : opts.arguments) {
+            switch(pair.first) {
+            case 'h':
+                usage(opts.argv0);
+                return 0;
+            case 'V':
+                std::cout<<pvxs::version_information;
+                return 0;
+            case 'v':
+                verbose = true;
+                break;
+            case 'd':
+                logger_level_set("pvxs.*", Level::Debug);
+                break;
+            case 'w':
+                timeout = pair.second.as<double>();
+                break;
+            case 'r':
+                request = *pair.second;
+                break;
+            default:
+                usage(opts.argv0);
+                std::cerr<<"\nUnknown argument: "<<pair.first<<std::endl;
+                return 1;
             }
         }
 
-        if(optind==argc) {
-            usage(argv[0]);
-            std::cerr<<"\nExpected PV name\n";
+        if(opts.positional.size()<2) {
+            usage(opts.argv0);
+            std::cerr<<"\nExpected PV name and at least one value\n";
             return 1;
         }
 
-        std::string pvname(argv[optind++]);
+        const auto& pvname = opts.positional.front();
         std::map<std::string, std::string> values;
 
-        if(argc-optind==1 && std::string(argv[optind]).find_first_of('=')==std::string::npos) {
+        if(opts.positional.size()==2 && std::string(opts.positional[1]).find_first_of('=')==std::string::npos) {
             // only one field assignment, and field name omitted.
             // if JSON map, treat as entire struct.  Others imply .value
 
-            auto sval(argv[optind]);
+            const auto& sval = opts.positional[1];
             values[sval[0]=='{' ? "" : "value"] = sval;
 
         } else {
-            for(auto n : range(optind, argc)) {
-                std::string fv(argv[n]);
+            for(auto n : range(size_t(1), opts.positional.size())) {
+                std::string fv(opts.positional[n]);
                 auto sep = fv.find_first_of('=');
 
                 if(sep==std::string::npos) {

--- a/tools/testcliutil.cpp
+++ b/tools/testcliutil.cpp
@@ -1,0 +1,143 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * pvxs is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+
+#include <vector>
+#include <initializer_list>
+
+#include <string.h>
+
+#include <pvxs/unittest.h>
+#include <pvxs/util.h>
+
+#include <testMain.h>
+#include <epicsUnitTest.h>
+#include <dbDefs.h>
+
+#include "cliutil.h"
+
+namespace pvxs { namespace detail {
+
+template<typename E>
+struct test_print<std::vector<E>> {
+    template<class C>
+    static inline void op(C& strm, const std::vector<E>& v) {
+        bool first = true;
+        for(auto& e : v) {
+            if(first) {
+                first = false;
+            } else {
+                strm<<' ';
+            }
+            test_print<E>::op(strm, e);
+        }
+    }
+};
+
+template<>
+struct test_print<std::pair<char, ArgVal>> {
+    template<class C>
+    static inline void op(C& strm, const std::pair<char, ArgVal>& v) {
+        strm<<'-'<<v.first;
+        if(v.second.defined)
+            strm<<" "<<pvxs::escape(v.second.value);
+    }
+};
+
+}} // namespace::detail
+
+MAIN(testcliutil) {
+    testPlan(24);
+
+    {
+        testDiag("case @%d", __LINE__);
+        const char* argv[] = {"exe", "-v", "-a", "Aa", "hello"};
+        pvxs::GetOpt opts(NELEMENTS(argv), const_cast<char**>(argv), "a:v");
+        testOk(strcmp(opts.argv0, "exe")==0, "%s", opts.argv0);
+        decltype (opts.arguments) arguments({{'v', nullptr}, {'a',"Aa"}});
+        testArrEq(opts.arguments, arguments);
+        decltype (opts.positional) positional({"hello"});
+        testArrEq(opts.positional, positional);
+    }
+
+    {
+        testDiag("case @%d", __LINE__);
+        const char* argv[] = {"exe", "-v", "-a", "Aa", "hello"};
+        pvxs::GetOpt opts(NELEMENTS(argv), const_cast<char**>(argv), "va:");
+        testOk(strcmp(opts.argv0, "exe")==0, "%s", opts.argv0);
+        decltype (opts.arguments) arguments({{'v', nullptr}, {'a',"Aa"}});
+        testArrEq(opts.arguments, arguments);
+        decltype (opts.positional) positional({"hello"});
+        testArrEq(opts.positional, positional);
+    }
+
+    {
+        testDiag("case @%d", __LINE__);
+        const char* argv[] = {"exe", "-v", "hello", "-aAa"};
+        pvxs::GetOpt opts(NELEMENTS(argv), const_cast<char**>(argv), "va:");
+        testOk(strcmp(opts.argv0, "exe")==0, "%s", opts.argv0);
+        decltype (opts.arguments) arguments({{'v', nullptr}, {'a',"Aa"}});
+        testArrEq(opts.arguments, arguments);
+        decltype (opts.positional) positional({"hello"});
+        testArrEq(opts.positional, positional);
+    }
+
+    {
+        testDiag("case @%d", __LINE__);
+        const char* argv[] = {"exe", "-v", "hello", "-a"}; // missing value
+        pvxs::GetOpt opts(NELEMENTS(argv), const_cast<char**>(argv), "va:");
+        testOk(strcmp(opts.argv0, "exe")==0, "%s", opts.argv0);
+        decltype (opts.arguments) arguments({{'v', nullptr}, {'?',nullptr}});
+        testArrEq(opts.arguments, arguments);
+        decltype (opts.positional) positional({"hello"});
+        testArrEq(opts.positional, positional);
+    }
+
+    {
+        testDiag("case @%d", __LINE__);
+        const char* argv[] = {"exe", "-vvaTest", "hello"};
+        pvxs::GetOpt opts(NELEMENTS(argv), const_cast<char**>(argv), "va:");
+        testOk(strcmp(opts.argv0, "exe")==0, "%s", opts.argv0);
+        decltype (opts.arguments) arguments({{'v', nullptr}, {'v', nullptr}, {'a', "Test"}});
+        testArrEq(opts.arguments, arguments);
+        decltype (opts.positional) positional({"hello"});
+        testArrEq(opts.positional, positional);
+    }
+
+    {
+        testDiag("case @%d", __LINE__);
+        const char* argv[] = {"exe", "-vvQQ", "hello"};
+        pvxs::GetOpt opts(NELEMENTS(argv), const_cast<char**>(argv), "va:");
+        testOk(strcmp(opts.argv0, "exe")==0, "%s", opts.argv0);
+        decltype (opts.arguments) arguments({{'v', nullptr}, {'v', nullptr}, {-1, nullptr}});
+        testArrEq(opts.arguments, arguments);
+        decltype (opts.positional) positional({"hello"});
+        testArrEq(opts.positional, positional);
+    }
+
+    {
+        testDiag("case @%d", __LINE__);
+        const char* argv[] = {"exe", "-v", "--", "-vvaTest", "hello"};
+        pvxs::GetOpt opts(NELEMENTS(argv), const_cast<char**>(argv), "va:");
+        testOk(strcmp(opts.argv0, "exe")==0, "%s", opts.argv0);
+        decltype (opts.arguments) arguments({{'v', nullptr}});
+        testArrEq(opts.arguments, arguments);
+        decltype (opts.positional) positional({"-vvaTest", "hello"});
+        testArrEq(opts.positional, positional);
+    }
+
+    {
+        testDiag("case @%d", __LINE__);
+        const char* argv[] = {"exe", "--vvQQ", "hello"};
+        pvxs::GetOpt opts(NELEMENTS(argv), const_cast<char**>(argv), "va:");
+        testOk(strcmp(opts.argv0, "exe")==0, "%s", opts.argv0);
+        decltype (opts.arguments) arguments({{-1, "--vvQQ"}});
+        testArrEq(opts.arguments, arguments);
+        decltype (opts.positional) positional({"hello"});
+        testArrEq(opts.positional, positional);
+    }
+
+    return testDone();
+}

--- a/tools/testxput.cpp
+++ b/tools/testxput.cpp
@@ -1,0 +1,215 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * pvxs is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+
+#include <sstream>
+#include <functional>
+
+#include <testMain.h>
+
+#include <envDefs.h>
+#include <dbDefs.h>
+#include <epicsUnitTest.h>
+
+#define PVXS_ENABLE_EXPERT_API
+
+#include <pvxs/server.h>
+#include <pvxs/sharedpv.h>
+#include <pvxs/nt.h>
+#include <pvxs/unittest.h>
+
+#define REALMAIN pvxput
+#include "put.cpp"
+
+using namespace pvxs;
+
+namespace {
+struct Redirect {
+    std::ostream& ref;
+    std::streambuf *prev;
+    Redirect(std::ostream& ref, std::ostream& target)
+        :ref(ref)
+        ,prev(ref.rdbuf(target.rdbuf()))
+    {}
+    ~Redirect() {
+        ref.rdbuf(prev);
+    }
+};
+
+struct Run {
+    std::string out, err;
+    int code;
+
+    Run(std::initializer_list<std::string> args) {
+        std::vector<const char*> argv({"pvxput"});
+        {
+            testCase cmdline;
+            cmdline<<"exec: pvxput";
+            for(auto& arg : args) {
+                cmdline<<" '"<<arg<<'\'';
+                argv.push_back(arg.c_str());
+            }
+        }
+        std::ostringstream out, err;
+        {
+            Redirect rd_cout(std::cout, out);
+            Redirect rd_cerr(std::cerr, err);
+            try{
+                code = pvxput(argv.size(), (char**)argv.data());
+            }catch(std::exception& e){
+                testFail("Uncaught c++ exception: %s", e.what());
+                code = -1;
+            }
+        }
+        this->out = out.str();
+        this->err = err.str();
+        if(!this->out.empty())
+            testShow()<<"stdout:\n"<<this->out;
+        if(!this->err.empty())
+            testShow()<<"stderr:\n"<<this->err;
+
+    }
+
+    Run& exitWith(int expect) {
+        testOk(expect==code, "%d == %d", expect, code);
+        return *this;
+    }
+    Run& success() {
+        return exitWith(0);
+    }
+
+    testCase _lineMatching(const std::string& inp, const std::string& expr) {
+        std::istringstream strm(inp);
+        std::string line;
+        testCase c;
+        while(std::getline(strm, line)) {
+            if(c.setPassMatch(expr, line))
+                break;
+        }
+        return c;
+    }
+
+    inline
+    testCase outMatch(const std::string& expr) {
+        return _lineMatching(out, expr);
+    }
+    inline
+    testCase errMatch(const std::string& expr) {
+        return _lineMatching(err, expr);
+    }
+};
+
+} // namespace
+
+MAIN(testxput)
+{
+    testPlan(31);
+
+    auto pvI32(server::SharedPV::buildMailbox());
+    pvI32.open(nt::NTScalar{TypeCode::Int32}.create()
+               .update("value", 5));
+
+    auto pvI32arr(server::SharedPV::buildMailbox());
+    pvI32arr.open(nt::NTScalar{TypeCode::Int32A}.create());
+
+    auto pvS(server::SharedPV::buildMailbox());
+    pvS.open(nt::NTScalar{TypeCode::String}.create()
+               .update("value", "foo"));
+
+    auto pvE(server::SharedPV::buildMailbox());
+    pvE.open(nt::NTEnum{}.create()
+             .update("value.index", 0)
+             .update("value.choices", shared_array<const std::string>({"one", "two"})));
+
+    // setup isolated server
+    auto srv(server::Config::isolated()
+             .build()
+             .addPV("testI32", pvI32)
+             .addPV("arrI32", pvI32arr)
+             .addPV("testS", pvS)
+             .addPV("testE", pvE)
+             .start());
+
+    // setup environment for pvxput() to find only our isolated server
+    {
+        client::Config::defs_t envs;
+        srv.clientConfig().updateDefs(envs);
+        for(const auto& pair : envs) {
+            testShow()<<" "<<pair.first<<"="<<pair.second;
+            epicsEnvSet(pair.first.c_str(), pair.second.c_str());
+        }
+    }
+
+    {
+        Run run({"-v", "-d", "-w1", "-w", "2", "-r", "foo", "-h"});
+        run.success();
+        run.outMatch(".*Show this message.*");
+    }
+
+    {
+        Run run({"-V"});
+        run.success();
+        run.outMatch(".*PVXS.*");
+        run.outMatch(".*libevent.*");
+    }
+
+    {
+        Run run({});
+        run.exitWith(1);
+        testStrEq(run.out, "");
+        run.errMatch(".*Expected PV name.*");
+    }
+
+    {
+        Run run({"-w", "foo"});
+        run.exitWith(1);
+        testStrEq(run.out, "");
+        run.errMatch(".*Invalid.*foo.*");
+    }
+
+    Run({"testI32", "6"}).success();
+    testEq(pvI32.fetch()["value"].as<int32_t>(), 6);
+
+    Run({"testI32", "value=7"}).success();
+    testEq(pvI32.fetch()["value"].as<int32_t>(), 7);
+
+    Run({"testI32", R"({"value":8})"}).success();
+    testEq(pvI32.fetch()["value"].as<int32_t>(), 8);
+
+    Run({"arrI32", R"({"value":8})"}).exitWith(1);
+
+    Run({"arrI32", R"([3,4,5])"}).success();
+    testArrEq(pvI32arr.fetch()["value"].as<shared_array<const int32_t>>(),
+            shared_array<const int32_t>({3,4,5}));
+
+    Run({"arrI32", R"(value=[1,4])"}).success();
+    testArrEq(pvI32arr.fetch()["value"].as<shared_array<const int32_t>>(),
+            shared_array<const int32_t>({1,4}));
+
+    Run({"arrI32", R"({"value":[5,6]})"}).success();
+    testArrEq(pvI32arr.fetch()["value"].as<shared_array<const int32_t>>(),
+            shared_array<const int32_t>({5, 6}));
+
+    Run({"testS", "hello"}).success();
+    testEq(pvS.fetch()["value"].as<std::string>(), "hello");
+
+    Run({"testS", "value=world"}).success();
+    testEq(pvS.fetch()["value"].as<std::string>(), "world");
+
+    Run({"testS", R"({"value":"baz"})"}).success();
+    testEq(pvS.fetch()["value"].as<std::string>(), "baz");
+
+
+    Run({"testE", R"({"value":{"index":1, "choices":["A","B","C"]}})"}).success();
+    testEq(pvE.fetch()["value.index"].as<int32_t>(), 1);
+    Run({"testE", "C"}).success();
+    testEq(pvE.fetch()["value.index"].as<int32_t>(), 2);
+
+    // update choices and assign from string with one op.  A place where order matters...
+    Run({"testE", R"({"value":"d", "value.choices":["a","b","c","d"]})"}).exitWith(1);
+    Run({"testE", R"({"value.choices":["x","y","z","q"], "value":"x"})"}).success();
+
+    return testDone();
+}


### PR DESCRIPTION
Wrap YAJL parser from Base, which **requires Base >=3.15**.  Teach `pvxput` to make use of this.

Adds special case handling of `enum_t` at a low level through the `Struct` node.

Relaxes requirement to prefix Union member access with `->` at the beginning of an expression.

TODO:

- [ ] Assign `Any` by inferring a `TypeDef`.
- [ ] Handle uint64