### PR TITLE
udp: clarify orig/reply addressing, fix mcast handling

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -669,20 +669,20 @@ void Server::Pvt::onSearch(const UDPManager::Search& msg)
     // on UDPManager worker
 
     for(const auto& addr : ignoreList) { // expected to be a short list
-        if(msg.src.family()!=addr.family()) {
+        if(msg.origSrc.family()!=addr.family()) {
             // skip
-        } else if(msg.src->in.sin_addr.s_addr != addr->in.sin_addr.s_addr) {
+        } else if(msg.origSrc->in.sin_addr.s_addr != addr->in.sin_addr.s_addr) {
             // skip
         } else if(addr->in.sin_port==0) {
             // ignore all ports
             return;
-        } else if(msg.src->in.sin_port == addr->in.sin_port) {
+        } else if(msg.origSrc->in.sin_port == addr->in.sin_port) {
             // ignore specific sender port
             return;
         }
     }
 
-    log_debug_printf(serverio, "%s searching\n", msg.src.tostring().c_str());
+    log_debug_printf(serverio, "%s searching\n", msg.origSrc.tostring().c_str());
 
     searchOp._names.resize(msg.names.size());
     for(auto i : range(msg.names.size())) {
@@ -690,13 +690,13 @@ void Server::Pvt::onSearch(const UDPManager::Search& msg)
         searchOp._names[i]._claim = false;
     }
     static_assert(sizeof(searchOp._src) >= INET6_ADDRSTRLEN+1, "");
-    switch(msg.server.family()) {
+    switch(msg.replyDest.family()) {
     case AF_INET:
-        evutil_inet_ntop(AF_INET, &msg.server->in.sin_addr,
+        evutil_inet_ntop(AF_INET, &msg.replyDest->in.sin_addr,
                          searchOp._src, sizeof(searchOp._src)-1);
         break;
     case AF_INET6:
-        evutil_inet_ntop(AF_INET6, msg.server->in6.sin6_addr.s6_addr,
+        evutil_inet_ntop(AF_INET6, msg.replyDest->in6.sin6_addr.s6_addr,
                          searchOp._src, sizeof(searchOp._src)-1);
         break;
     default:

--- a/src/udp_collector.cpp
+++ b/src/udp_collector.cpp
@@ -129,7 +129,7 @@ UDPCollector::UDPCollector(UDPManager::Pvt *manager, int af, uint16_t requested_
     ,sock(af, SOCK_DGRAM, 0)
     ,rx(__FILE__, __LINE__,
         event_new(manager->loop.base, sock.sock, EV_READ|EV_PERSIST, &handle_static, this))
-    ,beaconMsg(src)
+    ,beaconMsg(origSrc)
 {
     manager->loop.assertInLoop();
 
@@ -238,7 +238,7 @@ bool UDPCollector::handle_one(const IfaceMap::Current& ifinfo)
 
     // For Search messages, we use PV name strings in-place by adding nils.
     // Ensure one extra byte at the end of the buffer for a nil after the last PV name
-    recvfromx rx{sock.sock, (char*)rxbuf, rxlen, &src, &dest};
+    recvfromx rx{sock.sock, (char*)rxbuf, rxlen, &origSrc, &origDest};
     const int nrx = rx.call();
 
     if(nrx>=0 && rx.ndrop!=0u && prevndrop!=rx.ndrop) {
@@ -255,12 +255,12 @@ bool UDPCollector::handle_one(const IfaceMap::Current& ifinfo)
         return false; // wait for more I/O
     }
 
-    if(dest.family()!=AF_UNSPEC)
-        dest.setPort(bind_addr.port());
+    if(origDest.family()!=AF_UNSPEC)
+        origDest.setPort(bind_addr.port());
 
-    if(src.isMCast()) {
+    if(origSrc.isMCast()) {
         // should never happen.  It it does, we won't be tricked into amplifying a DDoS.
-        log_debug_printf(logio, "Ignoring UDP with mcast source %s.\n", src.tostring().c_str());
+        log_debug_printf(logio, "Ignoring UDP with mcast source %s.\n", origSrc.tostring().c_str());
         return true;
     }
 
@@ -271,14 +271,16 @@ bool UDPCollector::handle_one(const IfaceMap::Current& ifinfo)
     }
     srcIface = &ifit->second;
 
+    replySrc->in.sin_family = replyDest->in.sin_family = AF_UNSPEC; // spoil, will be set later
+
     // detect "origin" and reply-from address.  (dest in request becomes source in reply)
     origin_t origin = Broadcast;
-    if(srcIface->isLO && dest.compare(lo_mcast_addr.addr,false)==0) {
+    if(srcIface->isLO && origDest.compare(lo_mcast_addr.addr,false)==0) {
         // packet forwarded by a local PVA peer (maybe us) as IPv4 local multicast
         origin = Forwarded;
         // UDP header info of forwarder not relevant to reply.  Spoil...
-        src = SockAddr(src.family(), src.port());
-        dest = SockAddr(dest.family(), dest.port());
+        origSrc = SockAddr(origSrc.family(), origSrc.port());
+        origDest = replySrc = SockAddr(origDest.family(), origDest.port());
         srcIface = nullptr;
 
     } else {
@@ -287,36 +289,38 @@ bool UDPCollector::handle_one(const IfaceMap::Current& ifinfo)
         //   broadcast, look up corresponding local iface addr
         //   multicast,
         // ensure that dest is an interface address
-        auto ifit(srcIface->bcast.find(dest));
+        auto ifit(srcIface->bcast.find(origDest));
         if(ifit!=srcIface->bcast.end()) {
             // dest is bcast, so replace with associated iface address
-            dest = ifit->second.withPort(dest.port());
+            replySrc = ifit->second.withPort(origDest.port());
 
-        } else if((ifit=srcIface->addrs.find(dest))!=srcIface->addrs.end()) {
+        } else if((ifit=srcIface->addrs.find(origDest))!=srcIface->addrs.end()) {
             // dest is interface address.  Nothing to do.
             origin = Forwarding;
+            replySrc = origDest;
 
         } else {
             // mcast
             // reply from an arbitrary address on the source interface
             bool found = false;
             for(auto& it : srcIface->addrs) {
-                if(it.first.family()==dest.family()) {
-                    dest = it.first.withPort(dest.port());
+                if(it.first.family()==origDest.family()) {
+                    replySrc = it.first.withPort(origDest.port());
                     found = true;
                     break;
                 }
             }
             if(!found) {
                 // let host mcast routing try...
-                dest = SockAddr(dest.family(), dest.port());
+                replySrc = SockAddr(origDest.family(), origDest.port());
             }
         }
     }
 
-    log_hex_printf(logio, Level::Debug, rxbuf, nrx, "UDP Rx %d, %s -> %s @%u (%s) : orig %d\n",
-                   nrx, src.tostring().c_str(), dest.tostring().c_str(), unsigned(rx.dstif), bind_addr.tostring().c_str(),
-                   origin);
+    log_hex_printf(logio, Level::Debug, rxbuf, nrx, "UDP Rx %d, %s -> %s @%u (%s) : orig %d replyfrom %s\n",
+                   nrx, origSrc.tostring().c_str(), origDest.tostring().c_str(),
+                   unsigned(rx.dstif), bind_addr.tostring().c_str(),
+                   origin, replySrc.tostring().c_str());
 
     process_one(rxbuf, nrx, origin, ifinfo);
     return true;
@@ -332,7 +336,7 @@ void UDPCollector::process_one(const uint8_t *buf, size_t nrx, origin_t origin,
     if(!M.good() || (head.flags&(pva_flags::Control|pva_flags::SegMask))) {
         // UDP packets can't contain control messages, or use segmentation
 
-        log_hex_printf(logio, Level::Debug, &buf[0], nrx, "Ignore UDP message from %s\n", src.tostring().c_str());
+        log_hex_printf(logio, Level::Debug, &buf[0], nrx, "Ignore UDP message from %s\n", origSrc.tostring().c_str());
         return;
     }
 
@@ -360,22 +364,25 @@ void UDPCollector::process_one(const uint8_t *buf, size_t nrx, origin_t origin,
 
         M.skip(3, __FILE__, __LINE__); // unused/reserved
 
+        SockAddr server;
         auto save_replyAddr = M.save();
         from_wire(M, server);
         from_wire(M, port);
         if(server.isAny()) {
-            server = src;
+            replyDest = origSrc; // default
             if(origin==Forwarded || origin==OriginTag) {
                 log_warn_printf(logio, "Forwarded SEARCH with reply to sender never works.  Ignore.%s", "\n");
                 return;
             }
+        } else {
+            replyDest = server;
         }
-        server.setPort(port);
+        replyDest.setPort(port);
 
         if(!M.good())
             return;
 
-        if(origin==Broadcast || dest.family()!=AF_INET) {
+        if(origin==Broadcast || origDest.family()!=AF_INET) {
             // bcast, mcast, or not ipv4
 
         } else if(origin==Forwarding) {
@@ -385,7 +392,7 @@ void UDPCollector::process_one(const uint8_t *buf, size_t nrx, origin_t origin,
             // recipient of forwarded message must use, and trust, replyAddr in body :(
             {
                 FixedBuf R(M.be, save_replyAddr, 16u);
-                to_wire(R, server);
+                to_wire(R, replyDest);
                 assert(R.good());
             }
             forwardM(buf, nrx);
@@ -396,7 +403,7 @@ void UDPCollector::process_one(const uint8_t *buf, size_t nrx, origin_t origin,
              * some PVA implementations don't prefix forwarded messages with CMD_ORIGIN_TAG
              */
             log_debug_printf(logio, "Ignore as originated for %s\n",
-                             dest.tostring().c_str());
+                             origDest.tostring().c_str());
         }
 
         // so far, only "tcp" transport has ever been seen.
@@ -436,15 +443,12 @@ void UDPCollector::process_one(const uint8_t *buf, size_t nrx, origin_t origin,
             M.skip(chlen.size, __FILE__, __LINE__);
         }
 
-        // used by our reply()
-        src = server;
-
         if(M.good()) {
             // ensure nil for final PV name
             *M.save() = '\0';
 
             for(auto L : listeners) {
-                if(L->searchCB && (L->dest.addr.isAny() || L->dest.addr==dest)) {
+                if(L->searchCB && (L->dest.addr.isAny() || L->dest.addr==origDest)) {
                     (L->searchCB)(*this);
                 }
             }
@@ -467,7 +471,7 @@ void UDPCollector::process_one(const uint8_t *buf, size_t nrx, origin_t origin,
         from_wire(M, beaconMsg.server);
         from_wire(M, port);
         if(beaconMsg.server.isAny()) {
-            beaconMsg.server = src;
+            beaconMsg.server = origSrc;
         }
         beaconMsg.server.setPort(port);
 
@@ -477,7 +481,7 @@ void UDPCollector::process_one(const uint8_t *buf, size_t nrx, origin_t origin,
 
         if(M.good()) {
             for(auto L : listeners) {
-                if(L->beaconCB && (L->dest.addr.isAny() || L->dest.addr==dest)) {
+                if(L->beaconCB && (L->dest.addr.isAny() || L->dest.addr==origDest)) {
                     (L->beaconCB)(beaconMsg);
                 }
             }
@@ -510,9 +514,13 @@ void UDPCollector::process_one(const uint8_t *buf, size_t nrx, origin_t origin,
             if(isany || ifit!=ifinfo.byAddr.end()) {
                 // original destination is wildcard, or local interface address
                 originaddr.setPort(bind_addr.port());
-                dest = originaddr;
-                if(!isany)
+                origDest = originaddr;
+                if(!isany) {
                     srcIface = ifit->second.first;
+                    replySrc = origDest;
+                } else {
+                    replySrc = SockAddr::any(origSrc.family());
+                }
                 process_one(M.save(), M.size(), OriginTag, ifinfo);
                 return;
 
@@ -536,7 +544,7 @@ void UDPCollector::process_one(const uint8_t *buf, size_t nrx, origin_t origin,
 void UDPCollector::forwardM(const uint8_t *pbuf, size_t plen)
 {
     log_debug_printf(logio, "Forward as originated for %s\n",
-                     dest.tostring().c_str());
+                     origDest.tostring().c_str());
 
     assert(buf.size() > cmd_origin_tag_size);
     assert(pbuf==&buf[cmd_origin_tag_size]);
@@ -545,17 +553,17 @@ void UDPCollector::forwardM(const uint8_t *pbuf, size_t plen)
         FixedBuf M(true, &buf[0], cmd_origin_tag_size);
 
         to_wire(M, Header{CMD_ORIGIN_TAG, 0, 16u});
-        to_wire(M, dest);
+        to_wire(M, origDest);
         assert(M.good());
         assert(M.save()==&buf[cmd_origin_tag_size]);
     }
 
     // mcast_prep_sendto() will override routing
     srcIface = nullptr;
-    dest = SockAddr(src.family());
+    replySrc = SockAddr(replySrc.family());
 
     sock.mcast_prep_sendto(lo_mcast_addr);
-    src = lo_mcast_addr.addr;
+    replyDest = lo_mcast_addr.addr;
     reply(&buf[0], cmd_origin_tag_size+plen);
 }
 
@@ -564,11 +572,11 @@ bool UDPCollector::reply(const void *msg, size_t msglen) const
     manager->loop.assertInLoop();
 
     log_hex_printf(logio, Level::Debug, msg, msglen, "Send %s -> %s, %s,%s\n",
-                   bind_addr.tostring().c_str(), src.tostring().c_str(),
-                   dest.tostring().c_str(), srcIface ? srcIface->name.c_str() : "N/A");
+                   bind_addr.tostring().c_str(), replyDest.tostring().c_str(),
+                   replySrc.tostring().c_str(), srcIface ? srcIface->name.c_str() : "N/A");
 
     // reply to original source, through the original interface, as from original destination
-    auto ntx = sendtox{sock.sock, (char*)msg, msglen, &src, &dest, srcIface ? srcIface->index : 0}.call();
+    auto ntx = sendtox{sock.sock, (char*)msg, msglen, &replyDest, &replySrc, srcIface ? srcIface->index : 0}.call();
     if(ntx<0) {
         int err = evutil_socket_geterror(sock.sock);
         if(err==SOCK_EWOULDBLOCK || err==EAGAIN || err==SOCK_EINTR) {
@@ -576,8 +584,8 @@ bool UDPCollector::reply(const void *msg, size_t msglen) const
         } else {
             log_warn_printf(logio, "UDP TX Error: bound:%s src:%s,%s dst:%s : (%d) %s\n",
                             name.c_str(),
-                            dest.tostring().c_str(), srcIface ? srcIface->name.c_str() : "N/A",
-                            src.tostring().c_str(),
+                            replySrc.tostring().c_str(), srcIface ? srcIface->name.c_str() : "N/A",
+                            replyDest.tostring().c_str(),
                             err, evutil_socket_error_to_string(err));
         }
         return false; // wait for more I/O

--- a/src/udp_collector.h
+++ b/src/udp_collector.h
@@ -46,9 +46,10 @@ struct PVXS_API UDPManager
 
     struct PVXS_API Search {
         std::vector<std::string> otherproto; // any protocols other than "tcp"
-        SockAddr src; // sender/client address
-        SockAddr dest; // destination IP used by client
-        SockAddr server;
+        SockAddr origSrc; // sender/client address
+        SockAddr origDest; // destination IP used by client
+        SockAddr replySrc;
+        SockAddr replyDest;
         const IfaceMap::Iface* srcIface = nullptr;
         uint32_t searchID=0;
         uint8_t peerVersion=0;

--- a/tools/mshim.cpp
+++ b/tools/mshim.cpp
@@ -103,9 +103,9 @@ struct App {
                     uint8_t(msg.mustReply ? pva_search_flags::MustReply : 0u),
                     0,0,0
                 });
-        assert(!msg.server.isAny() && msg.server.family()==AF_INET); // UDPManager has already handled this case
-        to_wire(buf, msg.server);
-        to_wire(buf, uint16_t(msg.server.port()));
+        assert(!msg.replyDest.isAny() && msg.replyDest.family()==AF_INET); // UDPManager has already handled this case
+        to_wire(buf, msg.replyDest);
+        to_wire(buf, uint16_t(msg.replyDest.port()));
 
         size_t nproto = msg.otherproto.size();
         if(msg.protoTCP)
@@ -166,8 +166,8 @@ struct App {
 
             } else {
                 log_debug_printf(applog, "Forwarded search to %s -> %s -> %s?\n",
-                                 msg.src.tostring().c_str(),
-                                 msg.server.tostring().c_str(),
+                                 msg.origSrc.tostring().c_str(),
+                                 msg.replyDest.tostring().c_str(),
                                  std::string(SB()<<dest).c_str());
             }
         }

--- a/tools/pvxvct.cpp
+++ b/tools/pvxvct.cpp
@@ -91,7 +91,8 @@ void usage(const char *name)
                "  -V               Print version and exit.\n"
                "  -C               Show only client Searches\n"
                "  -S               Show only server Beacons\n"
-               "  -B hostip[:port] Listen on the given interface(s).  May be repeated.\n"
+               "  -B <host/ip>[:port] Listen on the given interface(s).  May be repeated.\n"
+               "  -B <mcast>[,ttl#][@iface][:port]\n"
                "  -H host          Show only message sent from this peer.  May be repeated.\n"
                "  -P pvname        Show only searches for this PV name.  May be repeated.\n"
               <<std::endl;
@@ -199,7 +200,7 @@ int main(int argc, char *argv[])
 
         auto searchCB = [&opts](const pva::UDPManager::Search& msg)
         {
-            if(!opts.client || !opts.allowPeer(msg.src))
+            if(!opts.client || !opts.allowPeer(msg.origSrc))
                 return;
 
             if(!opts.pvnames.empty()) {
@@ -211,7 +212,7 @@ int main(int argc, char *argv[])
                 if(!show)
                     return;
             }
-            log_info_printf(out, "%s Searching for:\n", msg.src.tostring().c_str());
+            log_info_printf(out, "%s Searching for:\n", msg.origSrc.tostring().c_str());
             for(const auto pv : msg.names) {
                 log_info_printf(out, "  \"%s\"\n", pv.name);
             }


### PR DESCRIPTION
Clarify orig/reply addressing, fix mcast handling in mshim and vct.  In vct expand from addr to endpoint parsing.

#139