### PR TITLE
Reduce transient memory allocations

### DIFF
--- a/configure/toolchain.c
+++ b/configure/toolchain.c
@@ -14,7 +14,7 @@ CONFIG_LOADED=YES
 #if __GNUC__
 /* also true for clang */
 GNUISH=YES
-USR_CXXFLAGS += -std=c++11
+USR_CXXFLAGS += -std=c++17
 #endif
 
 #if __GNUC__ && !__clang__

--- a/setup.py
+++ b/setup.py
@@ -604,8 +604,8 @@ def define_DSOS(self):
     cxx11_flags = []
     if probe.try_compile('int probefn() { auto x=1; return x; }',
                          language='c++',
-                         extra_preargs=['-std=c++11']):
-        cxx11_flags += ['-std=c++11']
+                         extra_preargs=['-std=c++17']):
+        cxx11_flags += ['-std=c++17']
 
     pvxs_abi = '%(PVXS_MAJOR_VERSION)s.%(PVXS_MINOR_VERSION)s'%pvxsversion
     event_abi = '%(EVENT_VERSION_MAJOR)s.%(EVENT_VERSION_MINOR)s.%(EVENT_VERSION_PATCH)s'%eventversion

--- a/src/bitmask.cpp
+++ b/src/bitmask.cpp
@@ -42,9 +42,8 @@ BitMask::BitMask(std::initializer_list<size_t> bits, size_t nbits)
 }
 
 void BitMask::resize(size_t bits) {
-    // round up to multiple of 64
-    size_t storebits = ((bits-1u)|0x3f)+1u;
-    _words.resize(storebits/64u, 0u);
+    if(bits>=64*_words.size())
+        throw std::logic_error("BitMask too large");
     _size = uint16_t(bits);
 }
 

--- a/src/bitmask.h
+++ b/src/bitmask.h
@@ -8,7 +8,7 @@
 
 #include <ostream>
 #include <stdexcept>
-#include <vector>
+#include <array>
 #include <algorithm>
 #include <cstdint>
 
@@ -92,7 +92,7 @@ class BitMask : public detail::BitBase<BitMask> {
     // bit  0 - lsb of word 0
     // bit 63 - msb of word 0
     // bit 64 - lsb of word 1
-    std::vector<uint64_t> _words;
+    std::array<uint64_t, 4> _words{};
     // actual size in bits
     // _words.size()*64u >= _size
     uint16_t _size=0u;
@@ -124,7 +124,7 @@ public:
     inline bool empty() const { return _size==0u; }
 
     //! number of storage words
-    inline size_t wsize() const { return _words.size(); }
+    inline size_t wsize() const { return _size ? 1+(_size/64u) : 0; }
     //! storage word
     inline uint64_t& word(size_t i) { return _words[i]; }
     inline const uint64_t& word(size_t i) const { return _words[i]; }

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -781,8 +781,9 @@ bool Value::tryCopyIn(const void *ptr, StoreType type)
     }
 }
 
-void Value::traverse(const std::string &expr, bool modify, bool dothrow)
+void Value::traverse(const char* e, size_t l, bool modify, bool dothrow)
 {
+    std::string_view expr(e, l);
     size_t pos=0;
     bool maybedot = false;
 
@@ -966,28 +967,56 @@ void Value::traverse(const std::string &expr, bool modify, bool dothrow)
 Value Value::operator[](const std::string& name)
 {
     Value ret(*this);
-    ret.traverse(name, true, false);
+    ret.traverse(name.c_str(), name.size(), true, false);
     return ret;
 }
 
 const Value Value::operator[](const std::string& name) const
 {
     Value ret(*this);
-    ret.traverse(name, false, false);
+    ret.traverse(name.c_str(), name.size(), false, false);
+    return ret;
+}
+
+Value Value::operator[](const char* name)
+{
+    Value ret(*this);
+    ret.traverse(name, strlen(name), true, false);
+    return ret;
+}
+
+const Value Value::operator[](const char* name) const
+{
+    Value ret(*this);
+    ret.traverse(name, strlen(name), false, false);
     return ret;
 }
 
 Value Value::lookup(const std::string& name)
 {
     Value ret(*this);
-    ret.traverse(name, true, true);
+    ret.traverse(name.c_str(), name.size(), true, true);
     return ret;
 }
 
 const Value Value::lookup(const std::string& name) const
 {
     Value ret(*this);
-    ret.traverse(name, false, true);
+    ret.traverse(name.c_str(), name.size(), false, true);
+    return ret;
+}
+
+Value Value::lookup(const char* name)
+{
+    Value ret(*this);
+    ret.traverse(name, strlen(name), true, true);
+    return ret;
+}
+
+const Value Value::lookup(const char* name) const
+{
+    Value ret(*this);
+    ret.traverse(name, strlen(name), false, true);
     return ret;
 }
 

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -4,6 +4,7 @@
  * in file LICENSE that is included with this distribution.
  */
 
+#include <string_view>
 #include <cstring>
 #include <epicsAssert.h>
 
@@ -828,7 +829,7 @@ void Value::traverse(const std::string &expr, bool modify, bool dothrow)
 
             decltype (desc->mlookup)::const_iterator it;
 
-            const auto& name = expr.substr(pos, sep-pos);
+            const auto& name = std::string_view(expr).substr(pos, sep-pos);
 
             if(sep>0 && (it=desc->mlookup.find(name))!=desc->mlookup.end()) {
                 // found it
@@ -871,7 +872,7 @@ void Value::traverse(const std::string &expr, bool modify, bool dothrow)
                     decltype (desc->mlookup)::const_iterator it;
                     auto& fld = store->as<Value>();
 
-                    if(sep>0 && (it=desc->mlookup.find(expr.substr(pos, sep-pos)))!=desc->mlookup.end()) {
+                    if(sep>0 && (it=desc->mlookup.find(std::string_view(expr).substr(pos, sep-pos)))!=desc->mlookup.end()) {
                         // found it.
 
                         if(modify || fld.desc==&desc->members[it->second]) {
@@ -923,7 +924,7 @@ void Value::traverse(const std::string &expr, bool modify, bool dothrow)
             if(expr[pos]=='['
                     && sep!=std::string::npos && sep-pos>=2)
             {
-                auto index = parseTo<uint64_t>(expr.substr(pos+1, sep-1-pos));
+                auto index = parseTo<uint64_t>(std::string_view(expr).substr(pos+1, sep-1-pos));
                 auto& varr = store->as<shared_array<const void>>();
                 shared_array<const Value> arr;
                 if((varr.original_type()==ArrayType::Value)

--- a/src/dataimpl.h
+++ b/src/dataimpl.h
@@ -70,7 +70,7 @@ struct FieldDesc {
     // "fld.sub.leaf" -> rel index
     // For Struct, relative to this (always >=1)
     // For Union, offset in members array (one entry will always be zero)
-    std::map<std::string, size_t> mlookup;
+    std::map<std::string, size_t, std::less<>> mlookup;
 
     // child iteration.  child# -> ("sub", rel index in enclosing vector<FieldDesc>)
     std::vector<std::pair<std::string, size_t>> miter;

--- a/src/pvxs/data.h
+++ b/src/pvxs/data.h
@@ -705,7 +705,7 @@ public:
 
     // Struct/Union access
 private:
-    void traverse(const std::string& expr, bool modify, bool dothrow);
+    void traverse(const char *e, size_t l, bool modify, bool dothrow);
 public:
 
     /** Attempt to access a descendant field.
@@ -725,6 +725,8 @@ public:
      */
     Value operator[](const std::string& name);
     const Value operator[](const std::string& name) const;
+    Value operator[](const char* name);
+    const Value operator[](const char* name) const;
 
     /** Attempt to access a descendant field, or throw exception.
      *
@@ -737,6 +739,8 @@ public:
      */
     Value lookup(const std::string& name);
     const Value lookup(const std::string& name) const;
+    Value lookup(const char* name);
+    const Value lookup(const char* name) const;
 
     //! Number of child fields.
     //! Only Struct, StructA, Union, UnionA return non-zero

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -21,6 +21,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <atomic>
+#include <charconv>
 
 #include <ctype.h>
 
@@ -766,53 +767,47 @@ void threadOnce_(threadOnceInfo *info)
 }
 
 template<>
-double parseTo<double>(const std::string& s) {
-    size_t idx=0, L=s.size();
-    double ret;
-    try {
-        ret = std::stod(s, &idx);
-    }catch(std::invalid_argument& e) {
-        throw NoConvert(SB()<<"Invalid input : \""<<escape(s)<<"\" : "<<e.what());
-    }catch(std::out_of_range& e) {
-        throw NoConvert(SB()<<"Out of range : \""<<escape(s)<<"\" : "<<e.what());
+double parseTo<double>(const std::string_view &s) {
+    auto S = s.data(), E = s.data()+s.size();
+    double ret{};
+    auto [remainder, ec] = std::from_chars(S, E, ret);
+    if(ec!=std::errc()) {
+        throw NoConvert(SB()<<"Not double : "<<std::quoted(s)<<" : "<<std::make_error_code(ec).message());
+    } else if(remainder!=E) {
+        for(; isspace(*remainder); remainder++) {}
+        if(remainder!=E)
+            throw NoConvert(SB()<<"Extraneous characters after double: "<<std::quoted(s)<<"");
     }
-    for(; idx<L && isspace(s[idx]); idx++) {}
-    if(idx<L)
-        throw NoConvert(SB()<<"Extraneous characters after double: \""<<escape(s)<<"\"");
     return ret;
 }
 
 template<>
-uint64_t parseTo<uint64_t>(const std::string& s) {
-    size_t idx=0, L=s.size();
-    unsigned long long ret;
-    try {
-        ret = std::stoull(s, &idx, 0);
-    }catch(std::invalid_argument& e) {
-        throw NoConvert(SB()<<"Invalid input : \""<<escape(s)<<"\"");
-    }catch(std::out_of_range& e) {
-        throw NoConvert(SB()<<"Out of range : \""<<escape(s)<<"\"");
+uint64_t parseTo<uint64_t>(const std::string_view &s) {
+    auto S = s.data(), E = s.data()+s.size();
+    uint64_t ret{};
+    auto [remainder, ec] = std::from_chars(S, E, ret);
+    if(ec!=std::errc()) {
+        throw NoConvert(SB()<<"Not uint64 : "<<std::quoted(s)<<" : "<<std::make_error_code(ec).message());
+    } else if(remainder!=E) {
+        for(; isspace(*remainder); remainder++) {}
+        if(remainder!=E)
+            throw NoConvert(SB()<<"Extraneous characters after uint64: "<<std::quoted(s)<<"");
     }
-    for(; idx<L && isspace(s[idx]); idx++) {}
-    if(idx<L)
-        throw NoConvert(SB()<<"Extraneous characters after integer: \""<<escape(s)<<"\"");
     return ret;
 }
 
 template<>
-int64_t parseTo<int64_t>(const std::string& s) {
-    size_t idx=0, L=s.size();
-    long long ret;
-    try {
-        ret = std::stoll(s, &idx, 0);
-    }catch(std::invalid_argument& e) {
-        throw NoConvert(SB()<<"Invalid input : \""<<escape(s)<<"\"");
-    }catch(std::out_of_range& e) {
-        throw NoConvert(SB()<<"Out of range : \""<<escape(s)<<"\"");
+int64_t parseTo<int64_t>(const std::string_view& s) {
+    auto S = s.data(), E = s.data()+s.size();
+    int64_t ret{};
+    auto [remainder, ec] = std::from_chars(S, E, ret);
+    if(ec!=std::errc()) {
+        throw NoConvert(SB()<<"Not int64 : "<<std::quoted(s)<<" : "<<std::make_error_code(ec).message());
+    } else if(remainder!=E) {
+        for(; isspace(*remainder); remainder++) {}
+        if(remainder!=E)
+            throw NoConvert(SB()<<"Extraneous characters after int64: "<<std::quoted(s)<<"");
     }
-    for(; idx<L && isspace(s[idx]); idx++) {}
-    if(idx<L)
-        throw NoConvert(SB()<<"Extraneous characters after unsigned: \""<<escape(s)<<"\"");
     return ret;
 }
 

--- a/src/utilpvt.h
+++ b/src/utilpvt.h
@@ -22,6 +22,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <string_view>
 #include <sstream>
 #include <type_traits>
 #include <limits>
@@ -148,17 +149,17 @@ template<typename I>
 constexpr idetail::Range<I> range(I begin, I end) { return idetail::Range<I>{begin, end}; }
 
 template<typename T>
-T parseTo(const std::string& s); // not implemented
+T parseTo(const std::string_view& s); // not implemented
 
 template<>
 PVXS_API
-double parseTo<double>(const std::string& s);
+double parseTo<double>(const std::string_view& s);
 template<>
 PVXS_API
-uint64_t parseTo<uint64_t>(const std::string& s);
+uint64_t parseTo<uint64_t>(const std::string_view& s);
 template<>
 PVXS_API
-int64_t parseTo<int64_t>(const std::string& s);
+int64_t parseTo<int64_t>(const std::string_view& s);
 
 #ifdef _WIN32
 #  define RWLOCK_TYPE SRWLOCK

--- a/test/testput.cpp
+++ b/test/testput.cpp
@@ -512,7 +512,7 @@ struct CancelSource : public server::Source {
         chan->onOp([this](std::unique_ptr<server::ConnectOp>&& op) {
             op->onPut([this](std::unique_ptr<server::ExecOp>&& pop, Value&&) {
                 auto eop(std::move(pop));
-                eop->onCancel([this](){
+                eop->onCancel([this]() noexcept{
                     cancelled = true;
                 });
                 // never complete


### PR DESCRIPTION
As an prospective micro-optimization, reduce the number of short lived / transient allocations.  Principally from `std::string` and `BitMask` (containing a `std::vector`).

c++17 std::string_view interface, std::from_chars for parsing, and the associated "transparent comparator" feature for std::map.  Also switches `BitMask` from dynamic to a fixed maximum capacity of 256 bits.  Surely no one would ever need more, right?

Analysis using systemtap https://github.com/mdavidsaver/ltrace/blob/master/alloc_time.stp

Testing a single subscriber to a 1Hz NTScalar double.

Initially, 8x one seciond long lived allocations (updates to subscription cache) vs. 71 shorter lived allocations (8us -> ~512us).

```
Run for 4813878 us
untracked 2
tracked 83 allocs min 8 avg 96622 max 1001133
 value |-------------------------------------------------- count
     2 |                                                    0
     4 |                                                    0
     8 |@@@@@@@@@@@@@@@@@@@@@@@                            23
    16 |@@@@@@@@@@@                                        11
    32 |@@@@@@@@@@@                                        11
    64 |@@@@                                                4
   128 |@@@                                                 3
   256 |@@@@@@@@@@@@@@@@@@@                                19
   512 |@@@@                                                4
  1024 |                                                    0
  2048 |                                                    0
       ~
131072 |                                                    0
262144 |                                                    0
524288 |@@@@@@@@                                            8
1048576 |                                                    0
2097152 |                                                    0
```

With this branch 10x longer vs. 24x shorter.

```
Run for 5484305 us
untracked 3
tracked 40 allocs min 163 avg 250487 max 1001064
  value |-------------------------------------------------- count
     32 |                                                    0
     64 |                                                    0
    128 |@@@@@@                                              6
    256 |@@@@@@@@@@@@@@@@@@@@@@@@                           24
    512 |                                                    0
   1024 |                                                    0
        ~
 131072 |                                                    0
 262144 |                                                    0
 524288 |@@@@@@@@@@                                         10
1048576 |                                                    0
2097152 |                                                    0
```

Now the shortest allocations (~200us) are from libevent buffering and Values from the subscription update queue.  In line with my expectations.