### PR TITLE
server: monitor TX check buffer level on each iteration

### DIFF
--- a/src/servermon.cpp
+++ b/src/servermon.cpp
@@ -83,21 +83,7 @@ struct MonitorOp final : public ServerOp
         {
             // based on operation state, yes
             server->acceptor_loop.dispatch([op](){
-                auto ch(op->chan.lock());
-                if(!ch)
-                    return;
-                auto conn(ch->conn.lock());
-                if(!conn || conn->state==ConnBase::Disconnected)
-                    return;
-
-                auto bev(conn->connection());
-
-                if(bev && evbuffer_get_length(bufferevent_get_output(bev)) < conn->tcp_tx_limit) {
-                    doReply(op);
-                } else {
-                    // connection TX queue is too full
-                    conn->backlog.emplace_back([op]() { doReply(op); });
-                }
+                doReply(op);
             });
 
             op->scheduled = true;
@@ -111,6 +97,7 @@ struct MonitorOp final : public ServerOp
         }
     }
 
+    // on tcp worker thread
     static
     void doReply(const std::shared_ptr<MonitorOp>& self)
     {
@@ -118,16 +105,30 @@ struct MonitorOp final : public ServerOp
         if(!ch)
             return;
         auto conn = ch->conn.lock();
-        if(!conn || !conn->connection())
+        if(!conn || !conn->connection() || conn->state==ConnBase::Disconnected)
             return;
 
         Guard G(self->lock);
+
         self->scheduled = false;
 
         log_debug_printf(connio, "%s state=%d\n", __func__, self->state);
 
         if(self->state==Dead)
             return;
+
+        // check connection TX buffer level
+        {
+            auto bev = conn->connection();
+            if(evbuffer_get_length(bufferevent_get_output(bev)) >= conn->tcp_tx_limit) {
+                log_debug_printf(connio, "Client %s IOID %u TX queue is too full defer to backlog\n",
+                                 conn->peerName.c_str(), unsigned(self->ioid));
+
+                conn->backlog.emplace_back([self]() { doReply(self); });
+                self->scheduled = true;
+                return;
+            }
+        }
 
         uint8_t subcmd = 0u;
         if(self->state==Creating) {


### PR DESCRIPTION
Attempt to address #161.  Move check on connection buffer from `maybeReply()`, run when deciding whether to start draining subscription queue, into the beginning of `doReply()`.  There it will be run on each iteration.

Running only the first time permits a situation where a busy publishing can grow the queue without bound by keeping `doReply()` from idling.