### PR TITLE
Add USE_BUNDLE option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,11 @@ include $(TOP)/configure/CONFIG
 # Directories to build, any order
 DIRS += configure
 
+ifeq ($(USE_BUNDLE),YES)
+DIRS += bundle
+configure_DEPEND_DIRS = bundle
+endif
+
 DIRS += setup
 setup_DEPEND_DIRS = configure
 

--- a/bundle/Makefile
+++ b/bundle/Makefile
@@ -99,6 +99,12 @@ help:
 	$(ECHO) " # remove one target"
 	$(ECHO) " make -C bundle clean.<epics-arch> # remove for one target"
 
+install: libevent
+
+uninstall: clean
+
+runtests:
+
 libevent: libevent.$(EPICS_HOST_ARCH)
 
 clean:

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -35,6 +35,9 @@ CHECK_RELEASE = YES
 #HOST_OPT = NO
 #CROSS_OPT = NO
 
+# set to YES to build and use libevent from bundle directory
+USE_BUNDLE=NO
+
 # These allow developers to override the CONFIG_SITE variable
 # settings without having to modify the configure/CONFIG_SITE
 # file itself.

--- a/src/Makefile
+++ b/src/Makefile
@@ -111,6 +111,10 @@ endif
 
 LIB_SYS_LIBS += $(LIBEVENT_SYS_LIBS)
 
+ifeq ($(USE_BUNDLE),YES)
+BIN_INSTALLS_WIN32 += $(wildcard $(LIBEVENT_PREFIX)/lib/*.dll)
+endif
+
 #===========================
 
 include $(TOP)/configure/RULES


### PR DESCRIPTION
If `BUNDLE_BUILD` is set to `YES` via e.g. `CONFIG_SITE.local` then a `make` at top level will build `libevent` from `bundle` directory without it needing to be built separately first; `bundle` is also added to the clean target and DLLs are installed to pvxs bin directory so the libevent bin area does not need to be separately added to windows `PATH`   