### PR TITLE
Run our cfg/CONFIG* files when INSTALL_LOCATION set

### DIFF
--- a/configure/CONFIG
+++ b/configure/CONFIG
@@ -28,3 +28,7 @@ ifdef T_A
  -include $(TOP)/configure/O.$(T_A)/TOOLCHAIN
 endif
 
+ifneq ($(INSTALL_LOCATION),$(TOP))
+  include $(wildcard $(INSTALL_CFG)/CONFIG*)
+endif
+


### PR DESCRIPTION
I believe this fixes #165.

`configure/CONFIG` already repeats including the local `$(TOP)/configure/CONFIG_SITE*` files,
the solution is for it to include the `cfg/CONFIG*` files too if `INSTALL_LOCATION` has been set.
