### PR TITLE
client: refresh hostname search destinations

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -110,10 +110,10 @@ LIB_LIBS += $(LIBEVENT_BUNDLE_LIBS)
 endif
 
 LIB_SYS_LIBS += $(LIBEVENT_SYS_LIBS)
-LIB_SYS_LIBS_Darwin += resolv
-LIB_SYS_LIBS_Linux += resolv
-LIB_SYS_LIBS_freebsd += resolv
-LIB_SYS_LIBS_solaris += resolv
+pvxs_SYS_LIBS_Darwin += resolv
+pvxs_SYS_LIBS_Linux += resolv
+pvxs_SYS_LIBS_freebsd += resolv
+pvxs_SYS_LIBS_solaris += resolv
 
 #===========================
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -110,6 +110,10 @@ LIB_LIBS += $(LIBEVENT_BUNDLE_LIBS)
 endif
 
 LIB_SYS_LIBS += $(LIBEVENT_SYS_LIBS)
+LIB_SYS_LIBS_Darwin += resolv
+LIB_SYS_LIBS_Linux += resolv
+LIB_SYS_LIBS_freebsd += resolv
+LIB_SYS_LIBS_solaris += resolv
 
 #===========================
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -5,8 +5,16 @@
  */
 
 #include <algorithm>
+#include <ctime>
+#include <cstring>
 #include <set>
 #include <tuple>
+
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__sun)
+#  include <arpa/nameser.h>
+#  include <resolv.h>
+#  define PVXS_USE_DNS_TTL 1
+#endif
 
 #include <osiSock.h>
 #include <dbDefs.h>
@@ -42,6 +50,240 @@ constexpr timeval bucketIntervalFast{0,200000};
 constexpr timeval initialSearchDelay{0, 10000}; // 10 ms
 // number of buckets in the search ring
 constexpr size_t nBuckets = 30u;
+constexpr unsigned dnsTTLFallback = 300u;
+constexpr unsigned dnsRetry = 60u;
+
+std::string endpointAddressPart(const std::string& inp)
+{
+    auto end = inp.find_first_of(",@");
+    auto ep = inp.substr(0u, end);
+
+    if(ep.empty())
+        return ep;
+    if(ep[0]=='[') {
+        auto close = ep.find(']');
+
+        if(close!=std::string::npos)
+            return ep.substr(1u, close-1u);
+    }
+
+    auto first = ep.find(':');
+    auto last = ep.rfind(':');
+
+    if(first!=std::string::npos && first==last)
+        return ep.substr(0u, first);
+    return ep;
+}
+
+bool endpointUsesHostname(const std::string& inp)
+{
+    auto host(endpointAddressPart(inp));
+    char buf[sizeof(in6_addr)];
+
+    if(host.empty())
+        return false;
+    if(evutil_inet_pton(AF_INET, host.c_str(), buf)==1)
+        return false;
+    if(evutil_inet_pton(AF_INET6, host.c_str(), buf)==1)
+        return false;
+    return true;
+}
+
+#ifdef PVXS_USE_DNS_TTL
+bool dnsTTL(const std::string& host, const SockAddr& addr, unsigned& ttl)
+{
+    unsigned char answer[4096];
+    ns_msg handle;
+    int qtype;
+    const void *selected;
+    size_t selectedLen;
+    int len;
+    int count;
+    bool found = false;
+    unsigned best = 0u;
+
+    if(addr.family()==AF_INET) {
+        qtype = ns_t_a;
+        selected = &addr->in.sin_addr.s_addr;
+        selectedLen = sizeof(addr->in.sin_addr.s_addr);
+
+    } else if(addr.family()==AF_INET6) {
+        qtype = ns_t_aaaa;
+        selected = &addr->in6.sin6_addr;
+        selectedLen = sizeof(addr->in6.sin6_addr);
+
+    } else {
+        return false;
+    }
+
+    len = res_query(host.c_str(), ns_c_in, qtype, answer, sizeof(answer));
+    if(len < 0 || len > (int)sizeof(answer) || ns_initparse(answer, len, &handle))
+        return false;
+
+    count = ns_msg_count(handle, ns_s_an);
+    for(int i = 0; i < count; i++) {
+        ns_rr rr;
+
+        if(ns_parserr(&handle, ns_s_an, i, &rr))
+            continue;
+        if(ns_rr_type(rr) != qtype || ns_rr_class(rr) != ns_c_in)
+            continue;
+        if(ns_rr_rdlen(rr) != selectedLen)
+            continue;
+        if(memcmp(ns_rr_rdata(rr), selected, selectedLen) != 0)
+            continue;
+
+        if(!found || ns_rr_ttl(rr) < best)
+            best = ns_rr_ttl(rr);
+        found = true;
+    }
+    if(found) {
+        ttl = best;
+        return true;
+    }
+    return false;
+}
+#endif
+
+time_t currentTime()
+{
+    auto now = time(nullptr);
+
+    if(now==(time_t)-1)
+        now = 0;
+    return now;
+}
+
+bool computeIsUcast(const SockEndpoint& ep,
+                    const std::set<SockAddr, SockAddrOnlyLess>& bcasts)
+{
+    auto isucast = !ep.addr.isMCast();
+
+    if(isucast && ep.addr.family()==AF_INET && bcasts.find(ep.addr)!=bcasts.end())
+        isucast = false;
+    return isucast;
+}
+
+bool resolveSearchEndpoint(const std::string& source, uint16_t port,
+                           SockEndpoint& ep, time_t& expires)
+{
+    auto now(currentTime());
+
+    try {
+        ep = SockEndpoint(source, port);
+    }catch(std::exception& e){
+        expires = now + dnsRetry;
+        log_warn_printf(setup, "%s  Retrying address %s later\n", e.what(), source.c_str());
+        return false;
+    }
+
+    if(endpointUsesHostname(source)) {
+        unsigned ttl = dnsTTLFallback;
+
+#ifdef PVXS_USE_DNS_TTL
+        (void)dnsTTL(endpointAddressPart(source), ep.addr, ttl);
+#endif
+        expires = now + ttl;
+
+    } else {
+        expires = 0;
+    }
+    return true;
+}
+
+bool resolveNameServer(const std::string& source, uint16_t port,
+                       SockAddr& addr, time_t& expires)
+{
+    auto now(currentTime());
+
+    try {
+        addr.setAddress(source.c_str(), port);
+    }catch(std::exception& e) {
+        expires = now + dnsRetry;
+        log_warn_printf(setup, "%s  Retrying nameserver %s later\n", e.what(), source.c_str());
+        return false;
+    }
+
+    if(endpointUsesHostname(source)) {
+        unsigned ttl = dnsTTLFallback;
+
+#ifdef PVXS_USE_DNS_TTL
+        (void)dnsTTL(endpointAddressPart(source), addr, ttl);
+#endif
+        expires = now + ttl;
+
+    } else {
+        expires = 0;
+    }
+    return true;
+}
+
+bool refreshSearchDest(ContextImpl& context, ContextImpl::SearchDest& dest)
+{
+    auto now(currentTime());
+
+    if(!dest.stateful)
+        return false;
+    if(dest.expires && difftime(now, dest.expires) < 0.0)
+        return false;
+
+    SockEndpoint resolved;
+    time_t expires = 0;
+    bool wasResolved = dest.resolved;
+    auto oldDest(dest.dest);
+    auto oldIsUcast(dest.isucast);
+
+    if(!resolveSearchEndpoint(dest.source, context.effective.udp_port,
+                              resolved, expires)) {
+        dest.resolved = false;
+        dest.expires = expires;
+        return wasResolved;
+    }
+
+    dest.dest = resolved;
+    dest.isucast = computeIsUcast(dest.dest, context.searchBcasts);
+    dest.resolved = true;
+    dest.expires = expires;
+    return !wasResolved || oldDest!=dest.dest || oldIsUcast!=dest.isucast;
+}
+
+bool refreshNameServer(ContextImpl& context, ContextImpl::NameServerDest& ns)
+{
+    auto now(currentTime());
+
+    if(!ns.stateful)
+        return false;
+    if(ns.expires && difftime(now, ns.expires) < 0.0)
+        return false;
+
+    SockAddr resolved;
+    time_t expires = 0;
+    bool wasResolved = ns.resolved;
+    auto oldAddr(ns.addr);
+
+    if(!resolveNameServer(ns.source, context.effective.tcp_port,
+                          resolved, expires)) {
+        ns.resolved = false;
+        ns.expires = expires;
+        if(wasResolved && ns.conn) {
+            ns.conn->cleanup();
+            ns.conn.reset();
+        }
+        return wasResolved;
+    }
+
+    ns.addr = resolved;
+    ns.resolved = true;
+    ns.expires = expires;
+    if(!wasResolved || oldAddr!=ns.addr) {
+        if(ns.conn) {
+            ns.conn->cleanup();
+            ns.conn.reset();
+        }
+        return true;
+    }
+    return false;
+}
 
 /* our limit for UDP packet payload.
  * try not to fragment with usual MTU==1500 allowing for some overhead
@@ -544,10 +786,9 @@ ContextImpl::ContextImpl(const Config& conf, const evbase& tcp_loop)
 {
     searchBuckets.resize(nBuckets);
 
-    std::set<SockAddr, SockAddrOnlyLess> bcasts;
     for(auto& addr : searchTx4.broadcasts()) {
         addr.setPort(0u);
-        bcasts.insert(addr);
+        searchBcasts.insert(addr);
     }
 
     searchTx6.ipv6_only();
@@ -577,34 +818,43 @@ ContextImpl::ContextImpl(const Config& conf, const evbase& tcp_loop)
 
     for(auto& addr : effective.addressList) {
         SockEndpoint ep;
-        try {
-            ep = SockEndpoint(addr, effective.udp_port);
-        }catch(std::exception& e){
-            log_warn_printf(setup, "%s  Ignoring malformed address %s\n", e.what(), addr.c_str());
+        time_t expires = 0;
+        bool stateful = endpointUsesHostname(addr);
+
+        if(!resolveSearchEndpoint(addr, effective.udp_port, ep, expires)) {
+            if(stateful) {
+                SearchDest dest(addr, ep, false, true, expires);
+
+                dest.resolved = false;
+                searchDest.push_back(dest);
+            }
             continue;
         }
         assert(ep.addr.family()==AF_INET || ep.addr.family()==AF_INET6);
 
-        // if !bcast and !mcast
-        auto isucast = !ep.addr.isMCast();
-
-        if(isucast && ep.addr.family()==AF_INET && bcasts.find(ep.addr)!=bcasts.end())
-            isucast = false;
+        auto isucast = computeIsUcast(ep, searchBcasts);
 
         log_info_printf(io, "Searching to %s%s\n", std::string(SB()<<ep).c_str(), (isucast?" unicast":""));
-        searchDest.emplace_back(ep, isucast);
+        searchDest.emplace_back(addr, ep, isucast, stateful, expires);
     }
 
     for(auto& addr : effective.nameServers) {
         SockAddr saddr;
-        try {
-            saddr.setAddress(addr.c_str(), effective.tcp_port);
-        }catch(std::runtime_error& e) {
-            log_err_printf(setup, "%s  Ignoring...\n", e.what());
+        time_t expires = 0;
+        bool stateful = endpointUsesHostname(addr);
+
+        if(!resolveNameServer(addr, effective.tcp_port, saddr, expires)) {
+            if(stateful) {
+                NameServerDest dest(addr, saddr, true, expires);
+
+                dest.resolved = false;
+                nameServers.push_back(dest);
+            }
+            continue;
         }
 
         log_info_printf(io, "Searching to TCP %s\n", saddr.tostring().c_str());
-        nameServers.emplace_back(saddr, nullptr);
+        nameServers.emplace_back(addr, saddr, stateful, expires);
     }
 
     if(searchDest.empty() && nameServers.empty())
@@ -656,10 +906,12 @@ void ContextImpl::startNS()
     tcp_loop.call([this]() {
         // start connections to name servers
         for(auto& ns : nameServers) {
-            const auto& serv = ns.first;
-            ns.second = Connection::build(shared_from_this(), serv);
-            ns.second->nameserver = true;
-            log_debug_printf(io, "Connecting to nameserver %s\n", ns.second->peerName.c_str());
+            refreshNameServer(*this, ns);
+            if(!ns.resolved)
+                continue;
+            ns.conn = Connection::build(shared_from_this(), ns.addr);
+            ns.conn->nameserver = true;
+            log_debug_printf(io, "Connecting to nameserver %s\n", ns.conn->peerName.c_str());
         }
 
         if(event_add(nsChecker.get(), &tcpNSCheckInterval))
@@ -1152,6 +1404,10 @@ void ContextImpl::tickSearch(SearchKind kind, bool poked)
             to_wire(H, Header{CMD_SEARCH, 0, uint32_t(consumed-8u)});
         }
         for(auto& pair : searchDest) {
+            refreshSearchDest(*this, pair);
+            if(!pair.resolved)
+                continue;
+
             auto& dest = pair.dest.addr.family()==AF_INET ? searchTx4 : searchTx6;
 
             if(pair.isucast) {
@@ -1196,9 +1452,10 @@ void ContextImpl::tickSearch(SearchKind kind, bool poked)
         pport[0] = pport[1] = 0;
 
         for(auto& pair : nameServers) {
-            auto& serv = pair.second;
+            refreshNameServer(*this, pair);
+            auto& serv = pair.conn;
 
-            if(!serv->ready || !serv->connection())
+            if(!pair.resolved || !serv || !serv->ready || !serv->connection())
                 continue;
 
             auto tx = bufferevent_get_output(serv->connection());
@@ -1295,12 +1552,16 @@ void ContextImpl::tickBeaconCleanS(evutil_socket_t fd, short evt, void *raw)
 void ContextImpl::onNSCheck()
 {
     for(auto& ns : nameServers) {
-        if(ns.second && ns.second->state != ConnBase::Disconnected) // hold-off, connecting, or connected
+        refreshNameServer(*this, ns);
+        if(!ns.resolved)
             continue;
 
-        ns.second = Connection::build(shared_from_this(), ns.first);
-        ns.second->nameserver = true;
-        log_debug_printf(io, "Reconnecting nameserver %s\n", ns.second->peerName.c_str());
+        if(ns.conn && ns.conn->state != ConnBase::Disconnected) // hold-off, connecting, or connected
+            continue;
+
+        ns.conn = Connection::build(shared_from_this(), ns.addr);
+        ns.conn->nameserver = true;
+        log_debug_printf(io, "Reconnecting nameserver %s\n", ns.conn->peerName.c_str());
     }
 }
 

--- a/src/clientimpl.h
+++ b/src/clientimpl.h
@@ -6,7 +6,9 @@
 #ifndef CLIENTIMPL_H
 #define CLIENTIMPL_H
 
+#include <ctime>
 #include <list>
+#include <set>
 
 #include <epicsTime.h>
 #include <epicsEvent.h>
@@ -290,10 +292,16 @@ struct ContextImpl : public std::enable_shared_from_this<ContextImpl>
 
     // search destination address and whether to set the unicast flag
     struct SearchDest {
-        const SockEndpoint dest;
-        const bool isucast;
+        std::string source;
+        SockEndpoint dest;
+        bool isucast;
+        bool resolved = true;
+        bool stateful = false;
+        time_t expires = 0;
         bool lastSuccess = true;
-        SearchDest(SockEndpoint dest, bool isu) :dest(dest), isucast(isu) {}
+        SearchDest(const std::string& source, SockEndpoint dest, bool isu,
+                   bool stateful, time_t expires)
+            :source(source), dest(dest), isucast(isu), stateful(stateful), expires(expires) {}
     };
 
     std::vector<SearchDest> searchDest;
@@ -314,7 +322,20 @@ struct ContextImpl : public std::enable_shared_from_this<ContextImpl>
 
     std::map<SockAddr, std::weak_ptr<Connection>> connByAddr;
 
-    std::vector<std::pair<SockAddr, std::shared_ptr<Connection>>> nameServers;
+    struct NameServerDest {
+        std::string source;
+        SockAddr addr;
+        std::shared_ptr<Connection> conn;
+        bool resolved = true;
+        bool stateful = false;
+        time_t expires = 0;
+        NameServerDest(const std::string& source, const SockAddr& addr,
+                       bool stateful, time_t expires)
+            :source(source), addr(addr), stateful(stateful), expires(expires) {}
+    };
+
+    std::vector<NameServerDest> nameServers;
+    std::set<SockAddr, SockAddrOnlyLess> searchBcasts;
 
     evbase tcp_loop;
     const evevent searchRx4, searchRx6;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -11,6 +11,8 @@
 #include <limits>
 #include <cmath>
 
+#include <event2/util.h>
+
 #include <dbDefs.h>
 #include <osiSock.h>
 #include <epicsMath.h>
@@ -148,8 +150,84 @@ namespace {
  */
 constexpr double tmoScale = 4.0/3.0; // 40 second idle timeout / 30 configured
 
+std::string endpointAddressPart(const std::string& inp)
+{
+    auto end = inp.find_first_of(",@");
+    auto ep = inp.substr(0u, end);
+
+    if(ep.empty())
+        return ep;
+    if(ep[0]=='[') {
+        auto close = ep.find(']');
+
+        if(close!=std::string::npos)
+            return ep.substr(1u, close-1u);
+    }
+
+    auto first = ep.find(':');
+    auto last = ep.rfind(':');
+
+    if(first!=std::string::npos && first==last)
+        return ep.substr(0u, first);
+    return ep;
+}
+
+bool endpointUsesHostname(const std::string& inp)
+{
+    auto host(endpointAddressPart(inp));
+    char buf[sizeof(in6_addr)];
+
+    if(host.empty())
+        return false;
+    if(evutil_inet_pton(AF_INET, host.c_str(), buf)==1)
+        return false;
+    if(evutil_inet_pton(AF_INET6, host.c_str(), buf)==1)
+        return false;
+    return true;
+}
+
+bool listUsesHostname(const std::vector<std::string>& inp)
+{
+    for(auto& addr : inp) {
+        if(endpointUsesHostname(addr))
+            return true;
+    }
+    return false;
+}
+
+bool endpointSeen(const std::vector<SockEndpoint>& inp, const SockEndpoint& ep)
+{
+    for(auto& addr : inp) {
+        if(addr==ep)
+            return true;
+    }
+    return false;
+}
+
+void printAddressesPreservingHostnames(std::vector<std::string>& out,
+                                       const std::vector<std::string>& original)
+{
+    std::vector<std::string> temp;
+
+    temp.reserve(original.size());
+    for(auto& addr : original) {
+        try {
+            SockEndpoint ep(addr);
+
+            if(endpointUsesHostname(addr))
+                temp.push_back(addr);
+            else
+                temp.emplace_back(SB()<<ep);
+
+        }catch(std::runtime_error& e){
+            log_warn_printf(config, "Ignoring %s : %s\n", addr.c_str(), e.what());
+        }
+    }
+    out = std::move(temp);
+}
+
 void split_addr_into(const char* name, std::vector<std::string>& out, const std::string& inp,
-                     uint16_t defaultPort, bool required=false)
+                     uint16_t defaultPort, bool required=false, bool preserveHostnames=false)
 {
     size_t pos=0u;
 
@@ -164,9 +242,14 @@ void split_addr_into(const char* name, std::vector<std::string>& out, const std:
             auto temp(inp.substr(start, end==std::string::npos ? end : end-start));
             try {
                 SockEndpoint ep(temp);
-                if(ep.addr.port()==0)
-                    ep.addr.setPort(defaultPort);
-                out.push_back(SB()<<ep);
+                if(preserveHostnames && endpointUsesHostname(temp)) {
+                    out.push_back(temp);
+
+                } else {
+                    if(ep.addr.port()==0)
+                        ep.addr.setPort(defaultPort);
+                    out.push_back(SB()<<ep);
+                }
 
             } catch(std::exception& e){
                 if(required)
@@ -578,11 +661,13 @@ void _fromDefs(Config& self, const std::map<std::string, std::string>& defs, boo
     }
 
     if(pickone({"EPICS_PVA_ADDR_LIST"})) {
-        split_addr_into(pickone.name.c_str(), self.addressList, pickone.val, self.udp_port);
+        split_addr_into(pickone.name.c_str(), self.addressList, pickone.val,
+                        self.udp_port, false, true);
     }
 
     if(pickone({"EPICS_PVA_NAME_SERVERS"})) {
-        split_addr_into(pickone.name.c_str(), self.nameServers, pickone.val, self.tcp_port);
+        split_addr_into(pickone.name.c_str(), self.nameServers, pickone.val,
+                        self.tcp_port, false, true);
     }
 
     if(pickone({"EPICS_PVA_AUTO_ADDR_LIST"})) {
@@ -631,8 +716,11 @@ void Config::expand()
     if(tcp_port==0)
         tcp_port = 5075;
 
+    auto requestedAddressList(addressList);
     auto ifaces(parseAddresses(interfaces));
     auto addrs(parseAddresses(addressList));
+    auto requestedAddrs(addrs);
+    bool preserveAddressNames = listUsesHostname(requestedAddressList);
 
     if(ifaces.empty())
         ifaces.emplace_back(SockAddr::any(AF_INET));
@@ -645,7 +733,15 @@ void Config::expand()
 
     printAddresses(interfaces, ifaces);
     removeDups(addrs);
-    printAddresses(addressList, addrs);
+    if(preserveAddressNames) {
+        printAddressesPreservingHostnames(addressList, requestedAddressList);
+        for(auto& addr : addrs) {
+            if(!endpointSeen(requestedAddrs, addr))
+                addressList.emplace_back(SB()<<addr);
+        }
+    } else {
+        printAddresses(addressList, addrs);
+    }
 
     enforceTimeout(tcpTimeout);
 }

--- a/test/testconfig.cpp
+++ b/test/testconfig.cpp
@@ -96,11 +96,13 @@ void testDefs()
         defs["EPICS_PVA_BROADCAST_PORT"] = "1234";
         defs["EPICS_PVA_AUTO_ADDR_LIST"] = "NO";
         defs["EPICS_PVA_ADDR_LIST"] = "1.2.1.2 4.3.2.1:1234";
+        defs["EPICS_PVA_NAME_SERVERS"] = "localhost:9876";
         defs["EPICS_PVA_INTF_ADDR_LIST"] = "1.2.3.4 1.1.1.1";
         conf.applyDefs(defs);
         testEq(conf.udp_port, 1234);
         testFalse(conf.autoAddrList);
         testEq(conf.addressList, std::vector<std::string>({"1.2.1.2:1234", "4.3.2.1:1234"}));
+        testEq(conf.nameServers, std::vector<std::string>({"localhost:9876"}));
         testEq(conf.interfaces, std::vector<std::string>({"1.1.1.1", "1.2.3.4"}));
     }
 
@@ -188,12 +190,12 @@ void testDNS()
         testArrEq(conf.addressList, expect)<<" numeric address";
     }
     {
-        std::vector<std::string> expect({"127.0.0.1"});
+        std::vector<std::string> expect({"localhost"});
         client::Config conf;
         conf.addressList.push_back("localhost"); // copy
         conf.autoAddrList = false;
         conf.expand();
-        testArrEq(conf.addressList, expect)<<" localhost";
+        testArrEq(conf.addressList, expect)<<" localhost preserved";
     }
     {
         std::vector<std::string> expect;
@@ -209,7 +211,7 @@ void testDNS()
 
 MAIN(testconfig)
 {
-    testPlan(34);
+    testPlan(35);
     testSetup();
     testDefs();
     logger_config_env();


### PR DESCRIPTION
## Summary

This updates PVXS client hostname handling so `addressList` and `nameServers` entries remain stateful for the lifetime of a client context instead of being resolved once during config expansion or context creation.

The change preserves original hostname tokens through client config handling, refreshes due hostname entries lazily using DNS TTL/retry policy, and reconnects name-server connections when a hostname resolves to a new address.

## Why

Before this change:

- client config parsing/expansion resolved hostnames and reprinted them as numeric addresses
- `ContextImpl` then built fixed `searchDest` and `nameServers` vectors from those resolved addresses
- long-lived PVXS clients would therefore keep sending searches and using name-server connections based on startup-time DNS results

That meant DNS changes were not reflected until the PVXS client context was recreated.

This PR makes those destinations stateful over the life of the client context, using the existing search and name-server timers rather than adding a background DNS thread.

## Details

- Preserve original hostname tokens through client config handling so they are still available after `Config::expand()`.
- Keep numeric IP, multicast, interface, and auto-discovered address behavior static.
- Add private stateful endpoint handling for client `addressList` and `nameServers`.
- Track the source token, resolved endpoint, resolved/unresolved state, and next expiry/retry time for hostname-backed entries.
- Refresh due UDP search destinations at the start of the existing search path before sending.
- Refresh due TCP name-server destinations before connect/search use.
- If a name-server hostname resolves to a different address, clean up the old connection and let the existing reconnect path build a new one.
- Keep unresolved hostname entries present but fail closed until a later retry succeeds.
- Use DNS TTLs where available on supported POSIX resolver platforms:
  - A-record TTLs for selected IPv4 results
  - AAAA-record TTLs for selected IPv6 results
- Fall back to `300s` after successful lookups without a usable TTL and `60s` before retrying unresolved names.
- Update config tests to reflect that hostnames are preserved rather than always normalized to numeric addresses.

## Relationship To EPICS Base PR #862

This PR is **complementary to**, but does **not require**, [epics-base/epics-base#862](https://github.com/epics-base/epics-base/pull/862).

- This PVXS PR handles **client search/name-server destination statefulness** inside PVXS.
- EPICS Base PR #862 handles **Access Security HAG DNS statefulness and propagation to existing AS clients**.

So there is no new public EPICS Base API dependency here, but the two PRs fit the same larger goal: keeping long-lived PVXS behavior current when DNS changes at runtime.

## Testing

- `make -C pvxs`
- `pvxs/test/O.darwin-aarch64/testconfig`
  - passed `35/35`
- `pvxs/test/O.darwin-aarch64/testnamesrv`
  - passed `5/5`
- `git -C pvxs diff --check`

## Notes

This PR is intentionally scoped to PVXS client `addressList` and `nameServers`. It does not change generic resolver APIs or add a background refresh thread.
