### PR TITLE
client/server: reconfigure destinations from IfaceMap

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -516,8 +516,89 @@ Value buildCAMethod()
                    }).create();
 }
 
+std::vector<ContextImpl::SearchDest>
+ContextImpl::buildSearchDest(const Config& conf,
+                             const std::set<SockAddr, SockAddrOnlyLess>& bcasts,
+                             bool announce)
+{
+    std::vector<SearchDest> ret;
+
+    for(auto& addr : conf.addressList) {
+        SockEndpoint ep;
+        try {
+            ep = SockEndpoint(addr, conf.udp_port);
+        }catch(std::exception& e){
+            log_warn_printf(setup, "%s  Ignoring malformed address %s\n", e.what(), addr.c_str());
+            continue;
+        }
+        assert(ep.addr.family()==AF_INET || ep.addr.family()==AF_INET6);
+
+        // if !bcast and !mcast
+        auto isucast = !ep.addr.isMCast();
+
+        if(isucast && ep.addr.family()==AF_INET && bcasts.find(ep.addr)!=bcasts.end())
+            isucast = false;
+
+        if(announce)
+            log_info_printf(io, "Searching to %s%s\n", std::string(SB()<<ep).c_str(), (isucast?" unicast":""));
+
+        ret.emplace_back(ep, isucast);
+    }
+
+    return ret;
+}
+
+bool ContextImpl::searchDestEqual(const std::vector<SearchDest>& lhs,
+                                  const std::vector<SearchDest>& rhs)
+{
+    if(lhs.size()!=rhs.size())
+        return false;
+
+    for(size_t i=0; i<lhs.size(); i++) {
+        if(lhs[i].dest!=rhs[i].dest || lhs[i].isucast!=rhs[i].isucast)
+            return false;
+    }
+
+    return true;
+}
+
+void ContextImpl::reconfigureSearchDestIfNeeded()
+{
+    auto nextGeneration = ifmapGeneration;
+
+    try {
+        const auto ifmap(IfaceMap::instance());
+        nextGeneration = ifmap.revision();
+
+        if(nextGeneration==ifmapGeneration)
+            return;
+
+        Config next(requested);
+        next.expand();
+
+        std::set<SockAddr, SockAddrOnlyLess> bcasts;
+        for(auto& addr : searchTx4.broadcasts()) {
+            addr.setPort(0u);
+            bcasts.insert(addr);
+        }
+
+        auto nextDest(buildSearchDest(next, bcasts, false));
+        if(!searchDestEqual(searchDest, nextDest)) {
+            log_info_printf(setup, "Reconfigured client search destinations after interface change%s", "\n");
+            searchDest.swap(nextDest);
+        }
+
+    }catch(std::exception& e){
+        log_warn_printf(setup, "Unable to reconfigure client search destinations: %s\n", e.what());
+    }
+
+    ifmapGeneration = nextGeneration;
+}
+
 ContextImpl::ContextImpl(const Config& conf, const evbase& tcp_loop)
-    :effective([conf]() -> Config{
+    :requested(conf)
+    ,ifmapGeneration(IfaceMap::instance().revision())
+    ,effective([conf]() -> Config{
         Config eff(conf);
         eff.expand();
         return eff;
@@ -575,25 +656,8 @@ ContextImpl::ContextImpl(const Config& conf, const evbase& tcp_loop)
     searchTx4.enable_SO_RXQ_OVFL();
     searchTx6.enable_SO_RXQ_OVFL();
 
-    for(auto& addr : effective.addressList) {
-        SockEndpoint ep;
-        try {
-            ep = SockEndpoint(addr, effective.udp_port);
-        }catch(std::exception& e){
-            log_warn_printf(setup, "%s  Ignoring malformed address %s\n", e.what(), addr.c_str());
-            continue;
-        }
-        assert(ep.addr.family()==AF_INET || ep.addr.family()==AF_INET6);
-
-        // if !bcast and !mcast
-        auto isucast = !ep.addr.isMCast();
-
-        if(isucast && ep.addr.family()==AF_INET && bcasts.find(ep.addr)!=bcasts.end())
-            isucast = false;
-
-        log_info_printf(io, "Searching to %s%s\n", std::string(SB()<<ep).c_str(), (isucast?" unicast":""));
-        searchDest.emplace_back(ep, isucast);
-    }
+    auto initialDest(buildSearchDest(effective, bcasts, true));
+    searchDest.swap(initialDest);
 
     for(auto& addr : effective.nameServers) {
         SockAddr saddr;
@@ -1014,6 +1078,8 @@ void ContextImpl::onSearchS(evutil_socket_t fd, short evt, void *raw)
 
 void ContextImpl::tickSearch(SearchKind kind, bool poked)
 {
+    reconfigureSearchDestIfNeeded();
+
     // If kind == SearchKind::discover, then this is a discovery ping.
     // these are really empty searches with must-reply set.
     // So if !discover, then we should not be modifying any internal state

--- a/src/clientimpl.h
+++ b/src/clientimpl.h
@@ -7,6 +7,7 @@
 #define CLIENTIMPL_H
 
 #include <list>
+#include <set>
 
 #include <epicsTime.h>
 #include <epicsEvent.h>
@@ -255,6 +256,8 @@ struct ContextImpl : public std::enable_shared_from_this<ContextImpl>
         Stopped,
     } state = Init;
 
+    const Config requested;
+    uint64_t ifmapGeneration = 0u;
     const Config effective;
 
     const Value caMethod;
@@ -297,6 +300,12 @@ struct ContextImpl : public std::enable_shared_from_this<ContextImpl>
     };
 
     std::vector<SearchDest> searchDest;
+    PVXS_API static std::vector<SearchDest> buildSearchDest(const Config& conf,
+                                                            const std::set<SockAddr, SockAddrOnlyLess>& bcasts,
+                                                            bool announce);
+    PVXS_API static bool searchDestEqual(const std::vector<SearchDest>& lhs,
+                                         const std::vector<SearchDest>& rhs);
+    void reconfigureSearchDestIfNeeded();
 
     size_t currentBucket = 0u;
     // Channels where we have yet to send out an initial search request

--- a/src/evhelper.cpp
+++ b/src/evhelper.cpp
@@ -718,6 +718,7 @@ struct IfMapDaemon : private epicsThreadRunable {
     epicsMutex lock;
     epicsEvent wake;
     std::shared_ptr<const IfaceMap::Current> latest;
+    uint64_t generation = 1u;
     bool stop = false;
     epicsThread worker;
     IfMapDaemon()
@@ -749,7 +750,10 @@ struct IfMapDaemon : private epicsThreadRunable {
                     wake.wait(15.0); // arbitrary period...
                     next = IfaceMap::refresh();
                 }
-                latest.swap(next);
+                if(!latest || !latest->same(*next)) {
+                    latest.swap(next);
+                    generation++;
+                }
 
             } catch(std::exception& e){
                 log_crit_printf(logiface, "While updating IfaceMap : %s\n", e.what());
@@ -770,9 +774,10 @@ IfaceMap IfaceMap::instance()
     assert(ifmapper);
     Guard G(ifmapper->lock);
     auto ret(ifmapper->latest);
+    auto generation(ifmapper->generation);
     if(!ret)
         throw std::logic_error("No IfaceMap");
-    return IfaceMap(std::move(ret));
+    return IfaceMap(std::move(ret), generation);
 }
 
 void IfaceMap::cleanup()
@@ -799,6 +804,28 @@ std::shared_ptr<const IfaceMap::Current> IfaceMap::refresh()
         }
     }
     return next;
+}
+
+bool IfaceMap::Current::same(const Current& o) const
+{
+    if(byIndex.size()!=o.byIndex.size())
+        return false;
+
+    auto oit(o.byIndex.begin());
+    for(auto it(byIndex.begin()), end(byIndex.end()); it!=end; ++it, ++oit) {
+        if(it->first!=oit->first)
+            return false;
+
+        const auto& a = it->second;
+        const auto& b = oit->second;
+
+        if(a.name!=b.name || a.index!=b.index || a.isLO!=b.isLO)
+            return false;
+        if(a.addrs!=b.addrs || a.bcast!=b.bcast)
+            return false;
+    }
+
+    return true;
 }
 
 bool IfaceMap::has_address(uint64_t ifindex, const SockAddr &addr) const

--- a/src/evhelper.h
+++ b/src/evhelper.h
@@ -309,6 +309,8 @@ struct PVXS_API IfaceMap {
     static
     void cleanup();
 
+    uint64_t revision() const { return generation; }
+
     // return true if ifindex is valid, and addr an interface address assigned to it.
     bool has_address(uint64_t ifindex, const SockAddr& addr) const;
     // lookup interface name by index
@@ -345,12 +347,17 @@ struct PVXS_API IfaceMap {
         std::map<std::string, Iface*> byName;
         // map address to tuple of interface and broadcast?
         std::multimap<SockAddr, std::pair<Iface*, bool>, SockAddrOnlyLess> byAddr;
+
+        bool same(const Current& o) const;
     };
     std::shared_ptr<const Current> current;
+    uint64_t generation = 0u;
 
     IfaceMap() = default;
     IfaceMap(const IfaceMap&) = default;
     IfaceMap(std::shared_ptr<const Current>&& cur) : current(std::move(cur)) {}
+    IfaceMap(std::shared_ptr<const Current>&& cur, uint64_t generation)
+        : current(std::move(cur)), generation(generation) {}
     static
     std::shared_ptr<const Current> refresh();
 private:

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -382,8 +382,65 @@ std::ostream& operator<<(std::ostream& strm, const Server& serv)
     return strm;
 }
 
+std::vector<std::pair<SockEndpoint, bool>>
+Server::Pvt::buildBeaconDest(const Config& conf, uint16_t udp_port)
+{
+    std::vector<std::pair<SockEndpoint, bool>> ret;
+
+    for(const auto& addr : conf.beaconDestinations) {
+        ret.emplace_back(std::piecewise_construct,
+                         std::forward_as_tuple(addr.c_str(), udp_port),
+                         std::forward_as_tuple(true));
+    }
+
+    return ret;
+}
+
+bool Server::Pvt::beaconDestEqual(const std::vector<std::pair<SockEndpoint, bool>>& lhs,
+                                  const std::vector<std::pair<SockEndpoint, bool>>& rhs)
+{
+    if(lhs.size()!=rhs.size())
+        return false;
+
+    for(size_t i=0; i<lhs.size(); i++) {
+        if(lhs[i].first!=rhs[i].first)
+            return false;
+    }
+
+    return true;
+}
+
+void Server::Pvt::reconfigureBeaconDestIfNeeded()
+{
+    auto nextGeneration = ifmapGeneration;
+
+    try {
+        const auto ifmap(IfaceMap::instance());
+        nextGeneration = ifmap.revision();
+
+        if(nextGeneration==ifmapGeneration)
+            return;
+
+        Config next(requested);
+        next.expand();
+
+        auto nextDest(buildBeaconDest(next, effective.udp_port));
+        if(!beaconDestEqual(beaconDest, nextDest)) {
+            log_info_printf(serversetup, "Reconfigured server beacon destinations after interface change%s", "\n");
+            beaconDest.swap(nextDest);
+        }
+
+    }catch(std::exception& e){
+        log_warn_printf(serversetup, "Unable to reconfigure server beacon destinations: %s\n", e.what());
+    }
+
+    ifmapGeneration = nextGeneration;
+}
+
 Server::Pvt::Pvt(const Config &conf)
-    :effective(conf)
+    :requested(conf)
+    ,ifmapGeneration(IfaceMap::instance().revision())
+    ,effective(conf)
     ,beaconMsg(128)
     ,acceptor_loop("PVXTCP", epicsThreadPriorityCAServerLow-2)
     ,beaconSender4(AF_INET, SOCK_DGRAM, 0)
@@ -501,12 +558,12 @@ Server::Pvt::Pvt(const Config &conf)
             firstiface = false;
         }
 
-        for(const auto& addr : effective.beaconDestinations) {
-            beaconDest.emplace_back(std::piecewise_construct,
-                                    std::forward_as_tuple(addr.c_str(), effective.udp_port),
-                                    std::forward_as_tuple(true));
+        auto initialDest(buildBeaconDest(effective, effective.udp_port));
+        beaconDest.swap(initialDest);
+
+        for(const auto& dest : beaconDest) {
             log_debug_printf(serversetup, "Will send beacons to %s\n",
-                             std::string(SB()<<beaconDest.back().first).c_str());
+                             std::string(SB()<<dest.first).c_str());
         }
     });
 
@@ -765,6 +822,8 @@ void Server::Pvt::onSearch(const UDPManager::Search& msg)
 
 void Server::Pvt::doBeacons(short evt)
 {
+    reconfigureBeaconDestIfNeeded();
+
     log_debug_printf(serversetup, "Server beacon timer expires\n%s", "");
 
     VectorOutBuf M(true, beaconMsg);

--- a/src/serverconn.h
+++ b/src/serverconn.h
@@ -231,6 +231,9 @@ struct Server::Pvt
 
     std::weak_ptr<Server::Pvt> internal_self;
 
+    const Config requested;
+    uint64_t ifmapGeneration = 0u;
+
     // "const" after ctor
     Config effective;
 
@@ -248,6 +251,11 @@ struct Server::Pvt
     std::list<std::unique_ptr<UDPListener> > listeners;
     // destination address, and whether last sendto() succeeded
     std::vector<std::pair<SockEndpoint, bool>> beaconDest;
+    PVXS_API static std::vector<std::pair<SockEndpoint, bool>> buildBeaconDest(const Config& conf,
+                                                                               uint16_t udp_port);
+    PVXS_API static bool beaconDestEqual(const std::vector<std::pair<SockEndpoint, bool>>& lhs,
+                                         const std::vector<std::pair<SockEndpoint, bool>>& rhs);
+    void reconfigureBeaconDestIfNeeded();
     std::vector<SockAddr> ignoreList;
 
     std::list<ServIface> interfaces;

--- a/test/Makefile
+++ b/test/Makefile
@@ -59,6 +59,10 @@ TESTPROD_HOST += testconfig
 testconfig_SRCS += testconfig.cpp
 TESTS += testconfig
 
+TESTPROD_HOST += testifacereconfig
+testifacereconfig_SRCS += testifacereconfig.cpp
+TESTS += testifacereconfig
+
 TESTPROD_HOST += testwild
 testwild_SRCS += testwild.cpp
 TESTS += testwild

--- a/test/testifacereconfig.cpp
+++ b/test/testifacereconfig.cpp
@@ -1,0 +1,116 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * pvxs is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+
+#include <testMain.h>
+
+#include <set>
+#include <tuple>
+
+#include <epicsUnitTest.h>
+
+#define PVXS_ENABLE_EXPERT_API
+
+#include <pvxs/unittest.h>
+
+#include "clientimpl.h"
+#include "serverconn.h"
+
+using namespace pvxs;
+
+namespace {
+
+void addIface(IfaceMap::Current& cur, uint64_t index, const std::string& name, bool isLO)
+{
+    auto pair(cur.byIndex.emplace(std::piecewise_construct,
+                                  std::forward_as_tuple(index),
+                                  std::forward_as_tuple(name, index, isLO)));
+    pair.first->second.addrs.emplace(SockAddr("127.0.0.1"), SockAddr("127.255.255.255"));
+}
+
+void testIfaceMapCurrentSame()
+{
+    testShow()<<__func__;
+
+    IfaceMap::Current one, two;
+
+    testTrue(one.same(two));
+
+    addIface(one, 1u, "lo0", true);
+    addIface(two, 1u, "lo0", true);
+    testTrue(one.same(two));
+
+    two.byIndex.begin()->second.name = "lo1";
+    testFalse(one.same(two));
+
+    two.byIndex.begin()->second.name = "lo0";
+    two.byIndex.begin()->second.addrs.clear();
+    testFalse(one.same(two));
+}
+
+void testClientSearchDest()
+{
+    testShow()<<__func__;
+
+    client::Config conf;
+    conf.udp_port = 1234u;
+    conf.autoAddrList = false;
+    conf.addressList = {"1.2.3.4", "5.6.7.8:9876"};
+
+    std::set<SockAddr, SockAddrOnlyLess> bcasts;
+    bcasts.emplace("1.2.3.4");
+
+    auto dest(client::ContextImpl::buildSearchDest(conf, bcasts, false));
+
+    testEq(dest.size(), 2u);
+    testFalse(dest[0].isucast);
+    testTrue(dest[1].isucast);
+    testEq(dest[0].dest.addr.port(), 1234u);
+    testEq(dest[1].dest.addr.port(), 9876u);
+
+    auto same(client::ContextImpl::buildSearchDest(conf, bcasts, false));
+    testTrue(client::ContextImpl::searchDestEqual(dest, same));
+
+    conf.addressList.pop_back();
+    auto changed(client::ContextImpl::buildSearchDest(conf, bcasts, false));
+    testFalse(client::ContextImpl::searchDestEqual(dest, changed));
+}
+
+void testServerBeaconDest()
+{
+    testShow()<<__func__;
+
+    server::Config conf;
+    conf.udp_port = 1234u;
+    conf.auto_beacon = false;
+    conf.beaconDestinations = {"1.2.3.4", "5.6.7.8:9876"};
+
+    auto dest(server::Server::Pvt::buildBeaconDest(conf, conf.udp_port));
+
+    testEq(dest.size(), 2u);
+    testEq(dest[0].first.addr.port(), 1234u);
+    testEq(dest[1].first.addr.port(), 9876u);
+    testTrue(dest[0].second);
+
+    auto same(server::Server::Pvt::buildBeaconDest(conf, conf.udp_port));
+    testTrue(server::Server::Pvt::beaconDestEqual(dest, same));
+
+    conf.beaconDestinations.pop_back();
+    auto changed(server::Server::Pvt::buildBeaconDest(conf, conf.udp_port));
+    testFalse(server::Server::Pvt::beaconDestEqual(dest, changed));
+}
+
+} // namespace
+
+MAIN(testifacereconfig)
+{
+    testPlan(17);
+    testSetup();
+    testIfaceMapCurrentSame();
+    testClientSearchDest();
+    testServerBeaconDest();
+    cleanup_for_valgrind();
+    return testDone();
+}


### PR DESCRIPTION
## Summary

This PR starts the runtime reconfiguration direction discussed in [epics-base/pvxs#173](https://github.com/epics-base/pvxs/issues/173).

It supersedes the DNS-first approach in #172 by focusing first on interface-derived runtime state:

- track `IfaceMap` revisions only when refreshed interface state actually changes
- keep the construction-time config as the reconfigure input
- rebuild client UDP search destinations through the existing `client::Config::expand()` path when `IfaceMap` changes
- rebuild server beacon destinations through the existing `server::Config::expand()` path when `IfaceMap` changes

The scope is intentionally limited to send-only destinations. It does not add DNS TTL handling, resolver dependencies, nameserver refresh, UDP listener rebinding, TCP listener bind/unbind behavior, or new public APIs.

## Why

The broader goal is to make PVXS converge on runtime network state changes without requiring process restart or context recreation.

This branch follows the architectural feedback in #173: prefer explicit reconfiguration that reuses the initial config expansion path instead of adding separate per-endpoint DNS/cache state.

## Follow-on Direction

This is intended as the first step in a broader reconfigure model. Follow-on work can extend the same pattern to:

- client beacon listeners
- server UDP search listeners
- TCP listener bind/unbind behavior
- TCP nameserver destinations
- QSRV / pvaLink reconfigure hooks
- diagnostics showing configured source, current expanded endpoints, and last reconfigure state

DNS hostname refresh should be revisited as an input to this reconfigure model rather than as a separate per-endpoint cache architecture.

## Testing

- `make -C pvxs`
- `test/O.darwin-aarch64/testifacereconfig`
  - passed `17/17`
- `test/O.darwin-aarch64/testconfig`
  - passed `34/34`
- `test/O.darwin-aarch64/testnamesrv`
  - passed `5/5`
- `git diff --check`

Note: the local build still emits existing Perl locale warnings for `C.UTF-8`. `testnamesrv` needs normal socket permissions and was rerun outside the sandbox after an initial sandbox `EPERM`.
