### PR TITLE
QSRV PUT optimizations

### DIFF
--- a/ioc/groupsource.cpp
+++ b/ioc/groupsource.cpp
@@ -34,11 +34,28 @@ namespace ioc {
 
 DEFINE_LOGGER(_logname, "pvxs.ioc.group.source");
 
+/**
+ * group security cache - for storing group security credentials and clients
+ */
+class GroupSecurityCache : public SecurityControlObject {
+public:
+    // references entry in IOCGroupConfig::groupMap
+    Group& group;
+    std::vector<SecurityClient> securityClients;
+    INST_COUNTER(GroupSecurityCache);
+
+    explicit GroupSecurityCache(Group& group) :group(group) {}
+};
+
 DEFINE_INST_COUNTER(GroupSourceSubscriptionCtx);
 DEFINE_INST_COUNTER(GroupSecurityCache);
 
+struct GroupPutInfo {
+    TriState forceProcessing{ Unset };
+};
+
 static
-void onOp(Group& group,
+void onOp(const std::shared_ptr<GroupSecurityCache>& securityCache,
           std::unique_ptr<server::ConnectOp>&& channelConnectOperation);
 static
 void onGet(Group& group, const std::unique_ptr<server::ExecOp>& getOperation);
@@ -98,8 +115,11 @@ void GroupSource::onCreate(std::unique_ptr<server::ChannelControl>&& channelCont
     auto it(config.groupMap.find(sourceName));
     if(it != config.groupMap.end()) {
         auto& group(it->second);
-        channelControl->onOp([&](std::unique_ptr<server::ConnectOp>&& channelConnectOperation) {
-            onOp(group, std::move(channelConnectOperation));
+
+        auto securityCache = std::make_shared<GroupSecurityCache>(group);
+
+        channelControl->onOp([securityCache](std::unique_ptr<server::ConnectOp>&& channelConnectOperation) {
+            onOp(securityCache, std::move(channelConnectOperation));
         });
 
         channelControl
@@ -162,8 +182,12 @@ void onDisableSubscription(const std::shared_ptr<GroupSourceSubscriptionCtx>& gr
  * @param channelConnectOperation the channel connect operation object
  */
 static
-void onOp(Group& group,
-        std::unique_ptr<server::ConnectOp>&& channelConnectOperation) {
+void onOp(const std::shared_ptr<GroupSecurityCache>& securityCache,
+          std::unique_ptr<server::ConnectOp>&& channelConnectOperation)
+{
+    // ok to allow reference to be captured.  Lifetime attached to global group config
+    auto& group = securityCache->group;
+
     // First stage for handling any request is to announce the channel type with a `connect()` call
     // @note The type signalled here must match the eventual type returned by a pvxs get
     channelConnectOperation->connect(group.valueTemplate);
@@ -173,16 +197,11 @@ void onOp(Group& group,
         onGet(group, getOperation);
     });
 
-    // Make a security cache for this client's connection to this group
-    // Each time the same client calls put we will reuse the cached security client
-    // The security cache will be deleted when the client disconnects from this group pv
-    auto securityCache = std::make_shared<GroupSecurityCache>();
-
     // register handler for pvxs group put
     channelConnectOperation
             ->onPut([&group, securityCache](std::unique_ptr<server::ExecOp>&& putOperation, Value&& value) {
                 if (!securityCache->done) {
-                    // First time we call put we need to initialise the security cache
+                    // First PUT on this Channel
                     securityCache->securityClients.resize(group.fields.size());
                     securityCache->credentials.reset(new Credentials(*putOperation->credentials()));
                     auto fieldIndex = 0u;
@@ -193,10 +212,9 @@ void onOp(Group& group,
                         }
                         fieldIndex++;
                     }
-                    auto& pvRequest = putOperation->pvRequest();
-                    IOCSource::setForceProcessingFlag(putOperation.get(), pvRequest, securityCache);
                     securityCache->done = true;
                 }
+                // for each PUT
 
                 onPutGroup(group, putOperation, value, *securityCache);
             });
@@ -515,6 +533,7 @@ void onGet(Group& group, const std::unique_ptr<server::ExecOp>& getOperation) {
 static
 bool putGroupField(const Value& value,
                    const Field& field,
+                   TriState forceProcessing,
                    const SecurityClient& securityClient,
                    const GroupSecurityCache& groupSecurityCache,
                    server::RemoteLogger& notify) {
@@ -535,7 +554,7 @@ bool putGroupField(const Value& value,
     }
     if (changing || field.info.type==MappingInfo::Proc) {
         // Do processing if required
-        IOCSource::doPostProcessing(field.value, groupSecurityCache.forceProcessing);
+        IOCSource::doPostProcessing(field.value, forceProcessing);
         return true;
     }
     return false;
@@ -581,6 +600,9 @@ void onPutGroup(Group& group, std::unique_ptr<server::ExecOp>& putOperation, con
         fieldIndex = 0;
 
         bool didSomething = false;
+        auto& pvRequest = putOperation->pvRequest();
+        TriState forceProcessing{Unset};
+        IOCSource::setForceProcessingFlag(putOperation.get(), pvRequest, forceProcessing);
 
         // If the group is configured for an atomic put operation,
         // then we need to put all the fields at once, so we lock them all together
@@ -591,7 +613,7 @@ void onPutGroup(Group& group, std::unique_ptr<server::ExecOp>& putOperation, con
             // Loop through all fields
             for (auto& field: group.fields) {
                 // Put the field
-                didSomething |= putGroupField(value, field,
+                didSomething |= putGroupField(value, field, forceProcessing,
                                               groupSecurityCache.securityClients[fieldIndex],
                                               groupSecurityCache,
                                               *putOperation);
@@ -612,7 +634,7 @@ void onPutGroup(Group& group, std::unique_ptr<server::ExecOp>& putOperation, con
                 // Lock this field
                 DBLocker F(pDbChannel->addr.precord);
                 // Put the field
-                didSomething |= putGroupField(value, field,
+                didSomething |= putGroupField(value, field, forceProcessing,
                                               groupSecurityCache.securityClients[fieldIndex],
                                               groupSecurityCache,
                                               *putOperation);

--- a/ioc/groupsource.cpp
+++ b/ioc/groupsource.cpp
@@ -37,6 +37,19 @@ DEFINE_LOGGER(_logname, "pvxs.ioc.group.source");
 DEFINE_INST_COUNTER(GroupSourceSubscriptionCtx);
 DEFINE_INST_COUNTER(GroupSecurityCache);
 
+static
+void onOp(Group& group,
+          std::unique_ptr<server::ConnectOp>&& channelConnectOperation);
+static
+void onGet(Group& group, const std::unique_ptr<server::ExecOp>& getOperation);
+
+static
+void onPutGroup(Group& group, std::unique_ptr<server::ExecOp>& putOperation, const Value& value,
+                const GroupSecurityCache& groupSecurityCache);
+
+static
+void onStartSubscription(const std::shared_ptr<GroupSourceSubscriptionCtx>& groupSubscriptionCtx);
+
 /**
  * Constructor for GroupSource registrar.
  */
@@ -131,7 +144,8 @@ void GroupSource::show(std::ostream& outputStream) {
  *
  * @param groupSubscriptionCtx the group subscription context
  */
-void GroupSource::onDisableSubscription(const std::shared_ptr<GroupSourceSubscriptionCtx>& groupSubscriptionCtx) {
+static
+void onDisableSubscription(const std::shared_ptr<GroupSourceSubscriptionCtx>& groupSubscriptionCtx) {
     for (auto& fieldSubscriptionCtx: groupSubscriptionCtx->fieldSubscriptionContexts) {
         fieldSubscriptionCtx.pValueEventSubscription.disable();
         fieldSubscriptionCtx.pPropertiesEventSubscription.disable();
@@ -147,7 +161,8 @@ void GroupSource::onDisableSubscription(const std::shared_ptr<GroupSourceSubscri
  * @param group the group to which the get/put operation pertains
  * @param channelConnectOperation the channel connect operation object
  */
-void GroupSource::onOp(Group& group,
+static
+void onOp(Group& group,
         std::unique_ptr<server::ConnectOp>&& channelConnectOperation) {
     // First stage for handling any request is to announce the channel type with a `connect()` call
     // @note The type signalled here must match the eventual type returned by a pvxs get
@@ -155,7 +170,7 @@ void GroupSource::onOp(Group& group,
 
     // register handler for pvxs group get
     channelConnectOperation->onGet([&group](std::unique_ptr<server::ExecOp>&& getOperation) {
-        get(group, getOperation);
+        onGet(group, getOperation);
     });
 
     // Make a security cache for this client's connection to this group
@@ -183,7 +198,7 @@ void GroupSource::onOp(Group& group,
                     securityCache->done = true;
                 }
 
-                putGroup(group, putOperation, value, *securityCache);
+                onPutGroup(group, putOperation, value, *securityCache);
             });
 }
 
@@ -195,7 +210,8 @@ void GroupSource::onOp(Group& group,
  * @param groupSubscriptionCtx the group subscription context
  * @param isStarting true if the client issued a start subscription request, false otherwise
  */
-void GroupSource::onStart(const std::shared_ptr<GroupSourceSubscriptionCtx>& groupSubscriptionCtx, bool isStarting) {
+static
+void onStart(const std::shared_ptr<GroupSourceSubscriptionCtx>& groupSubscriptionCtx, bool isStarting) {
     if (isStarting) {
         onStartSubscription(groupSubscriptionCtx);
     } else {
@@ -242,7 +258,8 @@ void subscriptionPost(GroupSourceSubscriptionCtx *pGroupCtx)
  *
  * @param groupSubscriptionCtx the group subscription context containing the field event subscriptions to start
  */
-void GroupSource::onStartSubscription(const std::shared_ptr<GroupSourceSubscriptionCtx>& groupSubscriptionCtx) {
+static
+void onStartSubscription(const std::shared_ptr<GroupSourceSubscriptionCtx>& groupSubscriptionCtx) {
     groupSubscriptionCtx->eventsEnabled = true;
     for (auto& fieldSubscriptionCtx: groupSubscriptionCtx->fieldSubscriptionContexts) {
         fieldSubscriptionCtx.pValueEventSubscription.enable();
@@ -430,7 +447,8 @@ bool getGroupField(const Field& field, Value valueTarget, const std::string& gro
  * @param group the group to get
  * @param getOperation the current executing operation
  */
-void GroupSource::get(Group& group, const std::unique_ptr<server::ExecOp>& getOperation) {
+static
+void onGet(Group& group, const std::unique_ptr<server::ExecOp>& getOperation) {
     bool atomic = group.atomicPutGet;
     getOperation->pvRequest()["record._options.atomic"].as(atomic);
 
@@ -531,7 +549,8 @@ bool putGroupField(const Value& value,
  * @param value the value being posted
  * @param groupSecurityCache the object that caches the security context of client connections
  */
-void GroupSource::putGroup(Group& group, std::unique_ptr<server::ExecOp>& putOperation, const Value& value,
+static
+void onPutGroup(Group& group, std::unique_ptr<server::ExecOp>& putOperation, const Value& value,
         const GroupSecurityCache& groupSecurityCache) {
     try {
         CurrentOp op(putOperation.get());

--- a/ioc/groupsource.h
+++ b/ioc/groupsource.h
@@ -45,27 +45,12 @@ private:
     IOCGroupConfig& config;
 
     // Handles all get, put and subscribe requests
-    static void onOp(Group& group, std::unique_ptr<server::ConnectOp>&& channelConnectOperation);
-
-    //////////////////////////////
-    // Get
-    //////////////////////////////
-    static void get(Group& group, const std::unique_ptr<server::ExecOp>& getOperation);
-
-    //////////////////////////////
-    // Put
-    //////////////////////////////
-    static void putGroup(Group& group, std::unique_ptr<server::ExecOp>& putOperation, const Value& value,
-            const GroupSecurityCache& groupSecurityCache);
 
     //////////////////////////////
     // Subscriptions
     //////////////////////////////
-	static void onDisableSubscription(const std::shared_ptr<GroupSourceSubscriptionCtx>& groupSubscriptionCtx);
-	static void onStartSubscription(const std::shared_ptr<GroupSourceSubscriptionCtx>& groupSubscriptionCtx);
 	void onSubscribe(const std::shared_ptr<GroupSourceSubscriptionCtx>& groupSubscriptionCtx,
 			std::unique_ptr<server::MonitorSetupOp>&& subscriptionOperation) const;
-    static void onStart(const std::shared_ptr<GroupSourceSubscriptionCtx>& groupSubscriptionCtx, bool isStarting);
 };
 
 } // ioc

--- a/ioc/iocsource.cpp
+++ b/ioc/iocsource.cpp
@@ -422,12 +422,10 @@ void IOCSource::doPostProcessing(dbChannel* pDbChannel, TriState forceProcessing
 
 /**
  * Set a flag that will force processing of record in the specified security control object
- *
- * @param pvRequest the request
- * @param securityControlObject the security control object to update
  */
-void IOCSource::setForceProcessingFlag(server::RemoteLogger *op, const Value& pvRequest,
-                                       const std::shared_ptr<SecurityControlObject>& securityControlObject)
+void IOCSource::setForceProcessingFlag(server::RemoteLogger *op,
+                                       const Value& pvRequest,
+                                       TriState& forceProc)
 {
     auto proc = pvRequest["record._options.process"];
     bool b;
@@ -436,12 +434,12 @@ void IOCSource::setForceProcessingFlag(server::RemoteLogger *op, const Value& pv
         return; // not provided
 
     } else if(proc.as(b)) { // actual bool, integer, or string parsable to bool
-        securityControlObject->forceProcessing = b ? True : False;
+        forceProc = b ? True : False;
         return;
 
     } else if(proc.as(s)) {
         if(s=="passive") {
-            securityControlObject->forceProcessing = Unset;
+            forceProc = Unset;
             return;
         }
     }

--- a/ioc/iocsource.h
+++ b/ioc/iocsource.h
@@ -64,7 +64,7 @@ public:
     static void
     setForceProcessingFlag(server::RemoteLogger *op,
                            const Value& pvRequest,
-                           const std::shared_ptr<SecurityControlObject>& securityControlObject);
+                           TriState &forceProc);
 };
 
 struct CurrentOp {

--- a/ioc/securityclient.h
+++ b/ioc/securityclient.h
@@ -35,18 +35,10 @@ public:
  */
 class SecurityControlObject {
 public:
-	bool done = false;
-	TriState forceProcessing{ Unset };
-};
-
-/**
- * group security cache - for storing group security credentials and clients
- */
-class GroupSecurityCache : public SecurityControlObject {
-public:
-	std::vector<SecurityClient> securityClients;
-	std::unique_ptr<Credentials> credentials;
-    INST_COUNTER(GroupSecurityCache);
+    // set by the first PUT to each Channel,
+    // when associated Credentials and SecurityClient(s) are initialized
+    bool done = false;
+    std::unique_ptr<Credentials> credentials;
 };
 
 /**
@@ -54,16 +46,16 @@ public:
  */
 class SingleSecurityCache : public SecurityControlObject {
 public:
-	SecurityClient securityClient;
-	std::unique_ptr<Credentials> credentials;
+    SecurityClient securityClient;
 };
 
 /**
  * The put operation cache for caching information about the current client put connection
  * Includes a single security cache as well as information pertaining to asynchronous put operations
  */
-struct PutOperationCache : public SingleSecurityCache {
+struct PutOperationCache {
 	bool doWait{ false };
+    TriState forceProcessing{ Unset };
 	processNotify notify{};
 	Value valueToSet;
 	std::unique_ptr<server::ExecOp> putOperation;

--- a/ioc/singlesource.cpp
+++ b/ioc/singlesource.cpp
@@ -320,6 +320,10 @@ void onOp(const std::shared_ptr<SingleInfo>& sInfo, const Value& valuePrototype,
     // Each time the same client calls put we will reuse the cached security client
     // The security cache will be deleted when the client disconnects from this pv
     auto putOperationCache = std::make_shared<PutOperationCache>();
+    putOperationCache->notify.usrPvt = putOperationCache.get();
+    putOperationCache->notify.chan = sInfo->chan;
+    putOperationCache->notify.putCallback = putCallback;
+    putOperationCache->notify.doneCallback = doneCallback;
 
     // Set up handler for put requests
     channelConnectOperation
@@ -328,30 +332,28 @@ void onOp(const std::shared_ptr<SingleInfo>& sInfo, const Value& valuePrototype,
                     Value&& value) {
                 try {
                     dbChannel* pDbChannel = sInfo->chan;
-                    if (!putOperationCache->done) {
-                        putOperationCache->credentials.reset(new Credentials(*putOperation->credentials()));
-                        putOperationCache->securityClient.update(pDbChannel, *putOperationCache->credentials);
-                        putOperationCache->notify.usrPvt = putOperationCache.get();
-                        putOperationCache->notify.chan = pDbChannel;
-                        putOperationCache->notify.putCallback = putCallback;
-                        putOperationCache->notify.doneCallback = doneCallback;
+                    if (!sInfo->done) {
+                        // initialize credentions on first PUT to this Channel
+                        sInfo->credentials.reset(new Credentials(*putOperation->credentials()));
+                        sInfo->securityClient.update(pDbChannel, *sInfo->credentials);
 
-                        auto& pvRequest = putOperation->pvRequest();
-                        pvRequest["record._options.block"].as<bool>(putOperationCache->doWait);
-                        IOCSource::setForceProcessingFlag(putOperation.get(), pvRequest, putOperationCache);
-                        if (putOperationCache->forceProcessing) {
-                            putOperationCache->doWait = false; // no point in waiting
-                        }
-                        putOperationCache->done = true;
+                        sInfo->done = true;
+                    }
+                    // for each PUT (may have different pvRequest)
+                    auto& pvRequest = putOperation->pvRequest();
+                    pvRequest["record._options.block"].as<bool>(putOperationCache->doWait);
+                    IOCSource::setForceProcessingFlag(putOperation.get(), pvRequest, putOperationCache->forceProcessing);
+                    if (putOperationCache->forceProcessing) {
+                        putOperationCache->doWait = false; // no point in waiting
                     }
 
                     SecurityLogger securityLogger;
 
                     IOCSource::doPreProcessing(pDbChannel,
                             securityLogger,
-                            *putOperationCache->credentials,
-                            putOperationCache->securityClient); // pre-process
-                    IOCSource::doFieldPreProcessing(putOperationCache->securityClient); // pre-process field
+                            *sInfo->credentials,
+                            sInfo->securityClient); // pre-process
+                    IOCSource::doFieldPreProcessing(sInfo->securityClient); // pre-process field
                     if (putOperationCache->doWait) {
                         putOperationCache->valueToSet = value;
                         // TODO prevent concurrent put with callbacks (notifyBusy)

--- a/ioc/singlesource.cpp
+++ b/ioc/singlesource.cpp
@@ -316,6 +316,10 @@ void onOp(const std::shared_ptr<SingleInfo>& sInfo, const Value& valuePrototype,
                 singleGet(*sInfo, getOperation, valuePrototype);
             });
 
+    // skip PUT specific allocations unless needed
+    if(channelConnectOperation->op()!=server::OpBase::Put)
+        return;
+
     // Make a security cache for this client's connection to this pv
     // Each time the same client calls put we will reuse the cached security client
     // The security cache will be deleted when the client disconnects from this pv

--- a/ioc/singlesrcsubscriptionctx.h
+++ b/ioc/singlesrcsubscriptionctx.h
@@ -16,11 +16,12 @@
 #include "fieldconfig.h"
 #include "subscriptionctx.h"
 #include "utilpvt.h"
+#include "securityclient.h"
 
 namespace pvxs {
 namespace ioc {
 
-struct SingleInfo : public MappingInfo {
+struct SingleInfo : public MappingInfo, public SingleSecurityCache {
     Channel chan;
     INST_COUNTER(SingleInfo);
 

--- a/src/osgroups.cpp
+++ b/src/osgroups.cpp
@@ -7,6 +7,8 @@
  */
 
 #include <vector>
+#include <map>
+#include <deque>
 
 #if defined(_WIN32)
 #  define USE_LANMAN
@@ -43,15 +45,26 @@ typedef gid_t osi_gid_t;
 #endif
 
 #include <epicsAssert.h>
+#include <epicsTime.h>
+#include <epicsGuard.h>
 
 #include "utilpvt.h"
+
+#if EPICS_VERSION_INT<VERSION_INT(7,0,3,1)
+#  define getMonotonic getCurrent
+#endif
 
 namespace pvxs {
 namespace impl {
 
+// manipulated for test code
+size_t rolesCacheMaxSize = 128u;
+double rolesCacheExpireTime = 60.0; // sec
+
 #if defined(USE_UNIX_GROUPS)
 
-void osdGetRoles(const std::string& account, std::set<std::string>& roles)
+static
+void osdGetRolesImpl(const std::string& account, std::set<std::string>& roles)
 {
     passwd *user = getpwnam(account.c_str());
     if(!user) {
@@ -126,7 +139,8 @@ void osdGetRoles(const std::string& account, std::set<std::string>& roles)
 
 #elif defined(USE_LANMAN)
 
-void osdGetRoles(const std::string& account, std::set<std::string>& roles)
+static
+void osdGetRolesImpl(const std::string& account, std::set<std::string>& roles)
 {
     NET_API_STATUS sts;
     LPLOCALGROUP_USERS_INFO_0 pinfo = NULL;
@@ -182,6 +196,7 @@ void osdGetRoles(const std::string& account, std::set<std::string>& roles)
 
 #else
 
+// nothing to cache
 void osdGetRoles(const std::string& account, std::set<std::string>& roles)
 {
     /* Group list not available (RTEMS, vxWorks)
@@ -190,5 +205,80 @@ void osdGetRoles(const std::string& account, std::set<std::string>& roles)
     roles.insert(account);
 }
 #endif
+
+#if defined(USE_UNIX_GROUPS) || defined(USE_LANMAN)
+
+namespace {
+
+struct rolesCache {
+    epicsMutex lock;
+
+    struct Entry;
+    // both map and dequeue iterators are stable through add/remove of others
+    typedef std::map<std::string, Entry> byAcct_t;
+    typedef std::deque<byAcct_t::iterator> byAge_t;
+
+    struct Entry {
+        std::set<std::string> roles;
+        epicsTime expires;
+        byAge_t::iterator it_age;
+    };
+
+    byAcct_t byAcct;
+    std::deque<byAcct_t::iterator> byAge; // oldest Entry first
+} *rolesC;
+
+void rolesInit() {
+    rolesC = new rolesCache;
+}
+
+} // namespace
+
+void osdGetRoles(const std::string& account, std::set<std::string>& roles)
+{
+    threadOnce<rolesInit>();
+    auto now(epicsTime::getMonotonic());
+    auto& rc = *rolesC;
+    epicsGuard<epicsMutex> G(rc.lock);
+
+    auto it_acct(rc.byAcct.find(account));
+    bool found = it_acct!=rc.byAcct.end();
+
+    if(!found || it_acct->second.expires <= now) {
+        // cache miss, new or expired
+        if(!found) {
+            // new entry, vacuum LRU
+            while(rc.byAge.size() > rolesCacheMaxSize) {
+                auto& it = rc.byAge.front();
+                assert(it->first!=account);
+
+                rc.byAcct.erase(it);
+                rc.byAge.pop_front();
+            }
+
+            auto p(rc.byAcct.emplace(account, rolesCache::Entry{}));
+            assert(p.second);
+            it_acct = std::move(p.first);
+            // cross-index
+            it_acct->second.it_age = rc.byAge.insert(rc.byAge.end(), it_acct);
+        }
+
+        // init/update entry
+
+        it_acct->second.expires = now + rolesCacheExpireTime;
+        try {
+            osdGetRolesImpl(account, it_acct->second.roles);
+        }catch(...){
+            // remove incomplete entry
+            rc.byAge.erase(it_acct->second.it_age);
+            rc.byAcct.erase(it_acct);
+            throw;
+        }
+    }
+
+    roles = it_acct->second.roles;
+}
+
+#endif // caching
 
 }} // namespace pvxs::impl

--- a/src/utilpvt.h
+++ b/src/utilpvt.h
@@ -215,6 +215,12 @@ public:
 #undef RWLOCK_RLOCK
 #undef RWLOCK_RUNLOCK
 
+// for test code
+PVXS_API
+extern size_t rolesCacheMaxSize;
+PVXS_API
+extern double rolesCacheExpireTime; // sec
+
 PVXS_API
 void osdGetRoles(const std::string& account, std::set<std::string>& roles);
 

--- a/test/testutil.cpp
+++ b/test/testutil.cpp
@@ -174,13 +174,31 @@ void testAccount()
     }
     testOk(!account.empty(), "User: '%s'", account.c_str());
 
-    std::set<std::string> roles;
-    osdGetRoles(account, roles);
+    // to force code coverage of roles cache cases:
+    // 1. new entry
+    // 2. expired entry
+    // 3. cache hit
+    rolesCacheMaxSize = 0;
+    rolesCacheExpireTime = -1.0;
+
+    std::set<std::string> roles, roles2;
+    osdGetRoles(account, roles); // cache miss, adds expired entry
+    rolesCacheExpireTime = 9999.0;
+    osdGetRoles(account, roles2); // cache miss, expired entry
+    osdGetRoles(account, roles2); // cache hit
 
     testNotEq(roles.size(), 0u);
+    testNotEq(roles2.size(), 0u);
     for(auto& role : roles) {
         testDiag(" %s", role.c_str());
     }
+
+    testTrue(roles.size()==roles2.size() && std::equal(roles.begin(), roles.end(), roles2.begin()));
+
+    roles.clear();
+    osdGetRoles("surely_invalid_account_name", roles);
+    testEq(roles.size(), 1u);
+    // new entry evicts 'account'
 }
 
 void testTestEq()
@@ -291,7 +309,7 @@ void testOnce()
 
 MAIN(testutil)
 {
-    testPlan(35);
+    testPlan(38);
     testTrue(version_abi_check())<<" 0x"<<std::hex<<PVXS_VERSION<<" ~= 0x"<<std::hex<<PVXS_ABI_VERSION;
     testServerGUID();
     testFill();


### PR DESCRIPTION
Attempting to address #176 by reducing calls to, and work by, `osdGetRoles()`.

- Restructure handling in single and group sources to make credential handling per Channel instead of per GET/PUT.
- Avoid some PUT specific allocations for GET.
- Add internal caching to `osdGetRoles()`.

Adds an expiring LRU cache to `osdGetRoles()` for targets using the `getpwnam()` or `NetUserGetLocalGroups()` implementations.  Cache is initially bounded to 128 entries, which will expire after 60 seconds.  This means that Channels created in the 60 seconds after a group list update becomes visible, would use the older list.  This has __security implications__.  I think acceptable to 99% of situations, where the group list is ~static.

@george-mcintyre fyi.

Python CI job failures due to https://github.com/epics-base/epicscorelibs/issues/48