### PR TITLE
qsrv & monitor: fix seven correctness issues

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -27,9 +27,6 @@ jobs:
           skip: true
 
         - ml: manylinux2014_x86_64
-          py: cp38-cp38
-
-        - ml: manylinux2014_x86_64
           py: cp39-cp39
 
         - ml: manylinux2014_x86_64
@@ -43,9 +40,6 @@ jobs:
 
         - ml: manylinux2014_x86_64
           py: cp313-cp313
-
-        - ml: manylinux2014_x86_64
-          py: cp313-cp313t
 
         - ml: manylinux_2_28_x86_64
           py: cp314-cp314

--- a/ioc/credentials.h
+++ b/ioc/credentials.h
@@ -13,6 +13,7 @@
 #include <vector>
 #include <string>
 
+#include <pvxs/iochooks.h>
 #include <pvxs/source.h>
 
 namespace pvxs {
@@ -28,6 +29,7 @@ class Credentials {
 public:
     std::vector<std::string> cred;
     std::string host;
+    PVXS_IOC_API
     explicit Credentials(const server::ClientCredentials& clientCredentials);
     Credentials(const Credentials&) = delete;
     Credentials(Credentials&&) = default;

--- a/ioc/groupsource.cpp
+++ b/ioc/groupsource.cpp
@@ -464,17 +464,28 @@ void GroupSource::get(Group& group, const std::unique_ptr<server::ExecOp>& getOp
 
         // Loop through all fields
         for (auto& field: group.fields) {
-            dbChannel* pDbChannel = field.value;
+            // Read every non-Proc/Structure field, exactly as the atomic branch
+            // does.  Channel-backed fields are locked for the duration of their
+            // read; channel-less readable fields (e.g. MappingInfo::Const, which
+            // carry a constant value rather than a dbChannel) have no lock but
+            // must still be populated, otherwise a non-atomic get silently drops
+            // them while the atomic get and monitor paths return them.
+            if(field.info.type == MappingInfo::Proc || field.info.type==MappingInfo::Structure)
+                continue;
 
             // find the leaf node in which to set the value
             auto leafNode = field.findIn(returnValue);
 
-            if (pDbChannel && leafNode) {
+            bool ok;
+            if (dbChannel* pDbChannel = field.value) {
                 // Lock this field
                 DBLocker F(pDbChannel->addr.precord);
-                if (!getGroupField(field, leafNode, group.name, getOperation)) {
-                    return;
-                }
+                ok = getGroupField(field, leafNode, group.name, getOperation);
+            } else {
+                ok = getGroupField(field, leafNode, group.name, getOperation);
+            }
+            if (!ok) {
+                return;
             }
         }
     }

--- a/ioc/groupsource.cpp
+++ b/ioc/groupsource.cpp
@@ -587,18 +587,22 @@ void GroupSource::putGroup(Group& group, std::unique_ptr<server::ExecOp>& putOpe
 
             // Loop through all fields
             for (auto& field: group.fields) {
-                dbChannel* pDbChannel = field.value;
-                if(!pDbChannel)
-                    continue;
-                // Lock this field
-                DBLocker F(pDbChannel->addr.precord);
-                // Put the field
-                didSomething |= putGroupField(value, field,
-                                              groupSecurityCache.securityClients[fieldIndex],
-                                              groupSecurityCache,
-                                              *putOperation);
+                if (dbChannel* pDbChannel = field.value) {
+                    // Lock this field
+                    DBLocker F(pDbChannel->addr.precord);
+                    // Put the field
+                    didSomething |= putGroupField(value, field,
+                                                  groupSecurityCache.securityClients[fieldIndex],
+                                                  groupSecurityCache,
+                                                  *putOperation);
+                    // Unlock this field when locker goes out of scope
+                }
+                // fieldIndex addresses the parallel securityClients vector, which
+                // is populated for every group.fields entry (channel-less ones
+                // included).  It must advance for every field, not only the
+                // channel-backed ones, or it drifts after the first channel-less
+                // field and authorises/audits the wrong field.
                 fieldIndex++;
-                // Unlock this field when locker goes out of scope
             }
         }
 

--- a/ioc/pvalink_link.cpp
+++ b/ioc/pvalink_link.cpp
@@ -84,8 +84,8 @@ void pvaLink::onTypeChange()
 {
     assert(lchan->connected && lchan->root); // we should only be called when connected
 
-    fld_value = fld_severity = fld_nanoseconds = fld_usertag
-            = fld_message = fld_severity = fld_meta = Value();
+    fld_value = fld_severity = fld_seconds = fld_nanoseconds = fld_usertag
+            = fld_message = fld_meta = Value();
 
     Value root;
     if(fieldName.empty()) {

--- a/ioc/pvalink_lset.cpp
+++ b/ioc/pvalink_lset.cpp
@@ -403,6 +403,12 @@ long pvaGetValue(DBLINK *plink, short dbrType, void *pbuffer, long *pnRequest) n
             self->snap_time.nsec = 0u;
         }
 
+        if(self->fld_usertag) {
+            self->snap_tag = self->fld_usertag.as<epicsUTag>();
+        } else {
+            self->snap_tag = 0;
+        }
+
         if(self->fld_severity) {
             self->snap_severity = self->fld_severity.as<uint16_t>();
         } else {

--- a/ioc/securityclient.h
+++ b/ioc/securityclient.h
@@ -15,6 +15,8 @@
 #include <dbChannel.h>
 #include <dbNotify.h>
 
+#include <pvxs/iochooks.h>
+
 #include "credentials.h"
 #include "typeutils.h"
 #include "utilpvt.h"
@@ -25,7 +27,9 @@ namespace ioc {
 class SecurityClient {
 public:
 	std::vector<ASCLIENTPVT> cli;
+	PVXS_IOC_API
 	~SecurityClient();
+	PVXS_IOC_API
 	void update(dbChannel* ch, Credentials& cred);
 	bool canWrite() const;
 };

--- a/ioc/securitylogger.h
+++ b/ioc/securitylogger.h
@@ -45,6 +45,7 @@ public:
                    const Credentials& credentials,
                    const SecurityClient& securityClient)
         :pfieldsave(pDbChannel->addr.pfield)
+        ,pchan(pDbChannel)
         ,pvt(asTrapWriteWithData((securityClient.cli)[0], // The user is the first element
                          credentials.cred[0].c_str(),     // The user is the first element
                          credentials.host.c_str(),

--- a/src/clientmon.cpp
+++ b/src/clientmon.cpp
@@ -777,7 +777,7 @@ std::shared_ptr<Subscription> MonitorBuilder::exec()
             try {
                 auto percent = parseTo<double>(sval.substr(0, sval.size()-1u));
                 if(percent>0.0 && percent<=100.0) {
-                    op->ackAt = uint32_t(percent * op->queueSize);
+                    op->ackAt = uint32_t(percent / 100.0 * op->queueSize);
                 } else {
                     throw std::invalid_argument("not in range (0%, 100%]");
                 }

--- a/src/servermon.cpp
+++ b/src/servermon.cpp
@@ -561,7 +561,7 @@ void ServerConn::handle_MONITOR()
                     if(sval.size()>1 && sval.back()=='%') {
                         try {
                             auto percent = parseTo<double>(sval.substr(0, sval.size()-1u));
-                            op->ackAt = std::max(0.0, std::min(percent, 100.0)) * op->limit;
+                            op->ackAt = std::max(0.0, std::min(percent, 100.0)) / 100.0 * op->limit;
                         }catch(std::exception& e){
                             logRemote(ioid, Level::Crit,
                                       SB()<<"Unable to parse% "<<pvRequest.nameOf(ackAny)<<" : "<<sval<<" : "<<e.what());

--- a/src/servermon.cpp
+++ b/src/servermon.cpp
@@ -312,7 +312,7 @@ struct ServerMonitorControl : public server::MonitorControlOp
         stat.maxQueue = mon->maxQueue;
         stat.limitQueue = mon->limit;
         stat.window = mon->window;
-        stat.nQueue = mon->nSquash;
+        stat.nSquash = mon->nSquash;
 
         if(reset)
             mon->maxQueue = mon->nSquash = 0u;

--- a/test/Makefile
+++ b/test/Makefile
@@ -160,6 +160,7 @@ TESTFILES += ../iq.db
 TESTFILES += ../ntenum.db
 TESTFILES += ../const.db
 TESTFILES += ../batch.db
+TESTFILES += ../secidxgroup.db
 TESTFILES += ../qgroup.cmd
 TESTFILES += ../qgroup.json
 TESTS += testqgroup

--- a/test/secidxgroup.db
+++ b/test/secidxgroup.db
@@ -1,0 +1,13 @@
+# A group whose first (put-order sorted) field is a channel-less
+# Structure, followed by a channel-backed puttable field.  A non-atomic group
+# put of value.x must authorise against value.x's own access-security client,
+# not drift onto the channel-less field's (empty, deny-all) client.
+record(longout, "$(P)secidx") {
+    field(VAL, "0")
+    info(Q:group, {
+        "$(P)SECIDX": {
+            "value": { +type:"structure" },
+            "value.x": { +type:"plain", +channel:"VAL", +putorder:0 }
+        }
+    })
+}

--- a/test/testmonpipe.cpp
+++ b/test/testmonpipe.cpp
@@ -97,6 +97,85 @@ struct Spammer : public server::Source {
     }
 };
 
+// Source which, on subscribe, fills the queue past its limit using post()
+// (which squashes when full) before the subscription is started, then captures
+// the server-side MonitorStat for inspection.  Used to regression test that
+// stats() reports the queue depth in nQueue and the squash count in nSquash,
+// rather than overwriting nQueue with the squash count.
+struct StatSquash : public server::Source {
+    const Value prototype;
+    const uint32_t nPost;
+
+    epicsEvent captured;
+    server::MonitorStat stat{};
+    std::shared_ptr<server::MonitorControlOp> keepalive;
+
+    explicit StatSquash(uint32_t nPost)
+        :prototype(nt::NTScalar{TypeCode::UInt32}.create())
+        ,nPost(nPost)
+    {}
+
+    virtual void onSearch(Search &op) override final {
+        for(auto& pv : op) {
+            if(strcmp(pv.name(), "sq")==0)
+                pv.claim();
+        }
+    }
+
+    virtual void onCreate(std::unique_ptr<server::ChannelControl> &&rop) override final {
+        if(rop->name()!="sq")
+            return;
+        auto op(std::move(rop));
+        auto ptype(prototype);
+        op->onSubscribe([this, ptype](std::unique_ptr<server::MonitorSetupOp>&& mop) {
+            // The subscription is created stopped, so nothing is sent and the
+            // queue is never drained while this callback runs (START is
+            // processed only after we return on the same acceptor loop).
+            std::shared_ptr<server::MonitorControlOp> ctrl(mop->connect(ptype));
+            for(uint32_t i=0; i<nPost; i++) {
+                auto next(ptype.cloneEmpty());
+                next["value"] = i; // distinct value each time so the update is "real"
+                ctrl->post(next);
+            }
+            ctrl->stats(stat);
+            keepalive = ctrl; // keep the subscription alive past this callback
+            captured.signal();
+        });
+    }
+};
+
+void testStatsSquash()
+{
+    testShow()<<__func__;
+
+    // queueSize 4, post 10 -> first 4 fill the queue, remaining 6 squash.
+    auto src(std::make_shared<StatSquash>(10u));
+
+    auto srv(server::Config::isolated().build()
+            .addSource("dut", src)
+            .start());
+
+    auto cli(srv.clientConfig().build());
+
+    auto mon(cli.monitor("sq")
+                 .record("queueSize", 4u)
+                 .maskConnected(true)
+                 .maskDisconnected(true)
+                 .event([](client::Subscription&){})
+                 .exec());
+
+    if(!src->captured.wait(5.0)) {
+        testFail("server onSubscribe never ran");
+        testSkip(3, "no stats captured");
+        return;
+    }
+
+    testEq(src->stat.limitQueue, 4u)<<" negotiated queueSize";
+    testEq(src->stat.nQueue, 4u)<<" nQueue must be the queue depth, not the squash count";
+    testEq(src->stat.nSquash, 6u)<<" nSquash must carry the squash count";
+    testEq(src->stat.maxQueue, 4u)<<" high-water queue depth";
+}
+
 void testSpam(uint32_t nQueue, uint32_t highMark, uint16_t lastVal,
               const std::string& ackAny="")
 {
@@ -152,9 +231,10 @@ void testSpam(uint32_t nQueue, uint32_t highMark, uint16_t lastVal,
 
 MAIN(testmonpipe)
 {
-    testPlan(111);
+    testPlan(115);
     testSetup();
     logger_config_env();
+    testStatsSquash();
     testSpam(3u, 0u, 7u);
     testSpam(2u, 0u, 5u);
     testSpam(4u, 0u, 9u);

--- a/test/testmonpipe.cpp
+++ b/test/testmonpipe.cpp
@@ -176,6 +176,86 @@ void testStatsSquash()
     testEq(src->stat.maxQueue, 4u)<<" high-water queue depth";
 }
 
+// Source: an ackAny percentage must be interpreted as a fraction of
+// the queue size, so ackAny="50%" with queueSize=4 yields ackAt=2.  The client
+// schedules an ack to the server only after it has pop()'d ackAt updates, and
+// the server reports a client ack by invoking onHighMark (here with a high
+// watermark of 0, so any ack fires it).  This source posts exactly 2 updates;
+// with the correct ackAt=2 the client acks and onHighMark fires, while the
+// buggy ackAt (percent*queueSize, clamped to queueSize=4) never reaches its
+// threshold after only 2 updates, so no ack is sent.
+struct AckPercent : public server::Source {
+    const Value prototype;
+
+    epicsEvent gotAck;
+    std::shared_ptr<server::MonitorControlOp> keepalive;
+
+    AckPercent()
+        :prototype(nt::NTScalar{TypeCode::UInt32}.create())
+    {}
+
+    virtual void onSearch(Search &op) override final {
+        for(auto& pv : op) {
+            if(strcmp(pv.name(), "ackpc")==0)
+                pv.claim();
+        }
+    }
+
+    virtual void onCreate(std::unique_ptr<server::ChannelControl> &&rop) override final {
+        if(rop->name()!="ackpc")
+            return;
+        auto op(std::move(rop));
+        auto ptype(prototype);
+        op->onSubscribe([this, ptype](std::unique_ptr<server::MonitorSetupOp>&& mop) {
+            std::shared_ptr<server::MonitorControlOp> ctrl(mop->connect(ptype));
+            ctrl->setWatermarks(0u, 0u); // onHighMark on any client ack
+            ctrl->onHighMark([this](){ gotAck.signal(); });
+            for(uint32_t i=0; i<2u; i++) {
+                auto next(ptype.cloneEmpty());
+                next["value"] = i;
+                ctrl->post(next);
+            }
+            keepalive = ctrl; // keep the subscription alive past this callback
+        });
+    }
+};
+
+void testAckPercent()
+{
+    testShow()<<__func__;
+
+    auto src(std::make_shared<AckPercent>());
+
+    auto srv(server::Config::isolated().build()
+            .addSource("dut", src)
+            .start());
+
+    auto cli(srv.clientConfig().build());
+
+    epicsEvent evt;
+    auto mon(cli.monitor("ackpc")
+                 .record("queueSize", 4u)
+                 .record("pipeline", true)
+                 .record("ackAny", "50%")
+                 .maskConnected(true)
+                 .maskDisconnected(true)
+                 .event([&evt](client::Subscription&){ evt.signal(); })
+                 .exec());
+
+    // Consume both updates so they count toward the client's ackAt threshold.
+    unsigned got = 0u;
+    while(got < 2u) {
+        if(mon->pop()) {
+            got++;
+        } else if(!evt.wait(5.0)) {
+            break;
+        }
+    }
+    testEq(got, 2u)<<" client received both updates";
+    testTrue(src->gotAck.wait(5.0))
+        <<" client must ack after ackAt=round(50% of queueSize 4)=2 updates";
+}
+
 void testSpam(uint32_t nQueue, uint32_t highMark, uint16_t lastVal,
               const std::string& ackAny="")
 {
@@ -231,10 +311,11 @@ void testSpam(uint32_t nQueue, uint32_t highMark, uint16_t lastVal,
 
 MAIN(testmonpipe)
 {
-    testPlan(115);
+    testPlan(117);
     testSetup();
     logger_config_env();
     testStatsSquash();
+    testAckPercent();
     testSpam(3u, 0u, 7u);
     testSpam(2u, 0u, 5u);
     testSpam(4u, 0u, 9u);

--- a/test/testpvalink.cpp
+++ b/test/testpvalink.cpp
@@ -435,6 +435,51 @@ namespace {
         dbScanUnlock((dbCommon*)inp);
     }
 
+    void testMetaTag()
+    {
+        testDiag("==== %s ====", __func__);
+
+#if EPICS_VERSION_INT >= VERSION_INT(7,0,6,0)
+        testqsrvWaitForLinkConnected("meta:inp.INP");
+
+        {
+            auto src = (aiRecord*)testdbRecordPtr("meta:src");
+            QSrvWaitForLinkUpdate U("meta:inp.INP");
+            dbScanLock((dbCommon*)src);
+            src->tse = epicsTimeEventDeviceTime;
+            src->time.secPastEpoch = 0x12345678;
+            src->time.nsec = 0x10203040;
+            src->utag = 0x0badf00du; // NT timeStamp.userTag is 32-bit
+            src->val = 5;            // within meta:src DRVL/DRVH [-10, 10]
+            dbProcess((dbCommon*)src);
+            dbScanUnlock((dbCommon*)src);
+        }
+        auto inp = (aiRecord*)testdbRecordPtr("meta:inp");
+
+        long ret;
+        double val;
+        epicsTimeStamp time;
+        epicsUTag tag = 0u;
+
+        dbScanLock((dbCommon*)inp);
+
+        // dbGetLink latches the meta-data captured from the remote update.
+        testTrue((ret=dbGetLink(&inp->inp, DBR_DOUBLE, &val, nullptr, nullptr))==0
+                 && val==5.0)<<" ret="<<ret<<" val="<<val;
+
+        // The remote timeStamp.userTag must be carried through to the link's
+        // getTimeStampTag, not left at the initial 0.
+        testTrue((ret=dbGetTimeStampTag(&inp->inp, &time, &tag))==0
+                 && time.secPastEpoch==0x12345678
+                 && tag==0x0badf00du)
+                <<" ret="<<ret<<" sec="<<time.secPastEpoch<<" tag="<<tag;
+
+        dbScanUnlock((dbCommon*)inp);
+#else
+        testSkip(2, "No userTag / getTimeStampTag before 7.0.6");
+#endif
+    }
+
     long setAMSG(dbCommon *prec)
     {
         (void)recGblSetSevrMsg(prec, READ_ALARM, MAJOR_ALARM, "%s", __func__);
@@ -633,7 +678,7 @@ extern "C" void testioc_registerRecordDeviceDriver(struct dbBase *);
 
 MAIN(testpvalink)
 {
-    testPlan(106);
+    testPlan(108);
     testSetup();
     pvxs::logger_config_env();
 
@@ -660,6 +705,7 @@ MAIN(testpvalink)
         testPutAsync();
         testDisconnect();
         testMeta();
+        testMetaTag();
         testMetaMS();
         testFwd();
         testAtomic();

--- a/test/testpvalink.cpp
+++ b/test/testpvalink.cpp
@@ -10,6 +10,7 @@
 #include <dbLock.h>
 #include <dbLink.h>
 #include <recGbl.h>
+#include <epicsTime.h>
 #include <dbUnitTest.h>
 #include <aiRecord.h>
 #include <aaoRecord.h>
@@ -480,6 +481,82 @@ namespace {
 #endif
     }
 
+    // A fixed field link (field:"x") whose remote sub-field flips from a
+    // timestamped struct to a bare scalar must not retain the struct's
+    // timeStamp.  onTypeChange()'s struct branch sets fld_seconds; the
+    // non-struct branch only sets fld_value.  Before the fix, fld_seconds was
+    // missing from the clear-list, so after the re-type it kept aliasing the
+    // previous struct's seconds and the link reported a stale timestamp.
+    void testTypeChange()
+    {
+        testDiag("==== %s ====", __func__);
+        using namespace pvxs::members;
+
+        const epicsUInt32 epicsSec = 0x12345678u; // expected EPICS-epoch seconds
+
+        auto serv(ioc::server());
+
+        // open #1: sub-field "x" is a timestamped, NTScalar-shaped struct.
+        Value asStruct(TypeDef(TypeCode::Struct, {
+            Struct("x", {
+                Float64("value"),
+                Struct("timeStamp", {
+                    Int64("secondsPastEpoch"),
+                    UInt32("nanoseconds"),
+                    UInt32("userTag"),
+                }),
+            }),
+        }).create());
+        asStruct["x.value"] = 12.0;
+        asStruct["x.timeStamp.secondsPastEpoch"] = uint64_t(epicsSec) + POSIX_TIME_AT_EPICS_EPOCH;
+
+        auto src(server::SharedPV::buildReadonly());
+        src.open(asStruct);
+        serv.addPV("tc:src", src);
+
+        testqsrvWaitForLinkConnected("tc:inp.INP");
+
+        auto inp = (aiRecord*)testdbRecordPtr("tc:inp");
+        long ret;
+        double val;
+        epicsTimeStamp time;
+
+        dbScanLock((dbCommon*)inp);
+        // struct branch: fld_value=x.value, fld_seconds=x.timeStamp.secondsPastEpoch
+        testTrue((ret=dbGetLink(&inp->inp, DBR_DOUBLE, &val, nullptr, nullptr))==0
+                 && val==12.0)<<" struct link value ret="<<ret<<" val="<<val;
+        testTrue((ret=dbGetTimeStamp(&inp->inp, &time))==0
+                 && time.secPastEpoch==epicsSec)
+                <<" struct branch latched seconds ret="<<ret<<" sec="<<time.secPastEpoch;
+        dbScanUnlock((dbCommon*)inp);
+
+        // Re-type: sub-field "x" becomes a bare scalar (the non-struct branch).
+        src.close();
+        testqsrvWaitForLinkConnected("tc:inp.INP", false);
+
+        Value asScalar(TypeDef(TypeCode::Struct, {
+            Float64("x"),
+        }).create());
+        asScalar["x"] = 34.0;
+        src.open(asScalar);
+        testqsrvWaitForLinkConnected("tc:inp.INP");
+
+        dbScanLock((dbCommon*)inp);
+        // non-struct branch: fld_value=root (the scalar x)
+        testTrue((ret=dbGetLink(&inp->inp, DBR_DOUBLE, &val, nullptr, nullptr))==0
+                 && val==34.0)<<" scalar link value ret="<<ret<<" val="<<val;
+        // fld_seconds must be cleared on the non-struct re-type, so the
+        // link reports no timestamp (0) rather than the stale struct seconds.
+        testTrue((ret=dbGetTimeStamp(&inp->inp, &time))==0
+                 && time.secPastEpoch==0u)
+                <<" stale struct seconds must not survive re-type ret="<<ret
+                <<" sec="<<time.secPastEpoch;
+        dbScanUnlock((dbCommon*)inp);
+
+        serv.removePV("tc:src");
+        src.close();
+    }
+
     long setAMSG(dbCommon *prec)
     {
         (void)recGblSetSevrMsg(prec, READ_ALARM, MAJOR_ALARM, "%s", __func__);
@@ -678,7 +755,7 @@ extern "C" void testioc_registerRecordDeviceDriver(struct dbBase *);
 
 MAIN(testpvalink)
 {
-    testPlan(108);
+    testPlan(112);
     testSetup();
     pvxs::logger_config_env();
 
@@ -706,6 +783,7 @@ MAIN(testpvalink)
         testDisconnect();
         testMeta();
         testMetaTag();
+        testTypeChange();
         testMetaMS();
         testFwd();
         testAtomic();

--- a/test/testpvalink.db
+++ b/test/testpvalink.db
@@ -224,3 +224,10 @@ record(aai, "target:ntndarray_inp") {
     field(NELM, "5")
     field(FTVL, "FLOAT")
 }
+
+# Regression: a fixed field link whose remote sub-field "x" flips
+# from a (timestamped) struct to a bare scalar across a re-type.  The
+# struct connection sets fld_seconds; the scalar reconnect must clear it.
+record(ai, "tc:inp") {
+    field(INP, {pva:{pv:"tc:src", field:"x"}})
+}

--- a/test/testqgroup.cpp
+++ b/test/testqgroup.cpp
@@ -717,6 +717,22 @@ void testConst()
               );
 }
 
+void testConstNonAtomicGet()
+{
+    testDiag("%s", __func__);
+    TestClient ctxt;
+
+    // A non-atomic group get must populate Const fields, identically to
+    // the atomic get / monitor paths exercised by testConst().  Before the fix
+    // the non-atomic get branch only read channel-backed fields, leaving the
+    // channel-less Const fields (s.i/s.d/s.s, which carry a constant value and
+    // have no dbChannel) at their cloneEmpty() defaults (0 / 0.0 / "").
+    auto val(ctxt.get("tst:const").record("atomic", false).exec()->wait(5.0));
+    testEq(val["s.i"].as<int64_t>(), int64_t(14));
+    testEq(val["s.d"].as<double>(), 1.5);
+    testStrEq(val["s.s"].as<std::string>(), "hello");
+}
+
 void testBatch()
 {
     testDiag("%s", __func__);
@@ -789,7 +805,7 @@ void testDbLoadGroup()
 
 MAIN(testqgroup)
 {
-    testPlan(43);
+    testPlan(46);
     testSetup();
     {
         generalTimeRegisterCurrentProvider("test", 1, &testTimeCurrent);
@@ -813,6 +829,7 @@ MAIN(testqgroup)
         testImage();
         testIQ();
         testConst();
+        testConstNonAtomicGet();
         testBatch();
         testGroupPutSecIndex();
         testDbLoadGroup();

--- a/test/testqgroup.cpp
+++ b/test/testqgroup.cpp
@@ -745,6 +745,28 @@ void testiocsh()
     }
 }
 
+// tst:SECIDX's first put-order-sorted field is a channel-less Structure,
+// and value.x is the channel-backed puttable field after it.  A non-atomic
+// group put of value.x must authorise against value.x's own security client.
+// Before the fix the non-atomic branch advanced the securityClients index only
+// for channel-backed fields, so after the channel-less Structure the index
+// drifted onto the empty (deny-all) client and the put was refused.
+void testGroupPutSecIndex()
+{
+    testDiag("%s", __func__);
+    TestClient ctxt;
+
+    bool ok = true;
+    try {
+        ctxt.put("tst:SECIDX").record("atomic", false).set("value.x", 5).exec()->wait(5.0);
+    } catch (std::exception& e) {
+        ok = false;
+        testDiag("non-atomic group put failed: %s", e.what());
+    }
+    testTrue(ok)<<" non-atomic group put authorised against the field's own security client";
+    testdbGetFieldEqual("tst:secidx", DBR_LONG, 5);
+}
+
 void testDbLoadGroup()
 {
     testDiag("%s", __func__);
@@ -767,7 +789,7 @@ void testDbLoadGroup()
 
 MAIN(testqgroup)
 {
-    testPlan(41);
+    testPlan(43);
     testSetup();
     {
         generalTimeRegisterCurrentProvider("test", 1, &testTimeCurrent);
@@ -782,6 +804,7 @@ MAIN(testqgroup)
         testdbReadDatabase("ntenum.db", nullptr, "P=enm");
         testdbReadDatabase("iq.db", nullptr, "N=iq:");
         testdbReadDatabase("const.db", nullptr, "P=tst:");
+        testdbReadDatabase("secidxgroup.db", nullptr, "P=tst:");
         testdbReadDatabase("batch.db", nullptr, "P=tst:b:");
         iocsh("../qgroup.cmd");
         ioc.init();
@@ -791,6 +814,7 @@ MAIN(testqgroup)
         testIQ();
         testConst();
         testBatch();
+        testGroupPutSecIndex();
         testDbLoadGroup();
         testiocsh();
     }

--- a/test/testqsingle.cpp
+++ b/test/testqsingle.cpp
@@ -23,6 +23,9 @@
 #include "dblocker.h"
 #include "testioc.h"
 #include "utilpvt.h"
+#include "securitylogger.h"
+#include "securityclient.h"
+#include "credentials.h"
 
 #include "capturestd.h"
 
@@ -633,6 +636,57 @@ void testPutLog()
               "host:user test:log Something -> Something\n");
 }
 
+// SecurityLogger must restore dbChannel addr.pfield over its lifetime.
+// The data-carrying constructor saved pfield and registered the asTrapWrite
+// hooks, but never assigned pchan -- so its restore (after the constructor's
+// asTrapWriteWithData) and the destructor's restore were both dead code.
+//
+// On this Base, asTrapWriteBeforeWithData/asTrapWriteAfterWrite already restore
+// pfield around each listener callback, so the defect cannot be observed
+// through an end-to-end put.  SecurityLogger's restore additionally guards the
+// rest of the put window (and older Base predating that asTrapWrite fix).  This
+// unit test clobbers pfield within the logger's lifetime and asserts the
+// destructor restores it -- which happens only once pchan is assigned.
+void testSecurityLoggerPfield()
+{
+    testDiag("%s", __func__);
+
+    dbChannel *chan = dbChannelCreate("test:pfield");
+    if(!chan || dbChannelOpen(chan)) {
+        testFail("could not open dbChannel test:pfield");
+        testSkip(1, "no channel");
+        if(chan)
+            dbChannelDelete(chan);
+        return;
+    }
+
+    server::ClientCredentials cc;
+    cc.peer = "127.0.0.1:0";
+    cc.iface = "127.0.0.1:0";
+    cc.method = "ca";
+    cc.account = "anonymous";
+
+    ioc::Credentials cred(cc);
+    ioc::SecurityClient sc;
+    sc.update(chan, cred);
+
+    void* const correct = chan->addr.pfield;
+
+    {
+        ioc::SecurityLogger sl(chan, cred, sc);
+        // Clobber pfield within the logger's lifetime -- the window asTrapWrite's
+        // own before/after restore does not cover.
+        chan->addr.pfield = (void*)&chan->addr.precord->proc;
+        testTrue(chan->addr.pfield != correct)<<" clobber applied";
+    } // SecurityLogger destructor must restore pfield here
+
+    testTrue(chan->addr.pfield == correct)
+        <<" SecurityLogger must restore addr.pfield, got "
+        <<chan->addr.pfield<<" want "<<correct;
+
+    dbChannelDelete(chan);
+}
+
 void testPutBlock()
 {
 #if EPICS_VERSION_INT >= VERSION_INT(3, 16, 0, 1)
@@ -1002,7 +1056,7 @@ void testiocsh(TestClient& ctxt)
 
 MAIN(testqsingle)
 {
-    testPlan(113);
+    testPlan(115);
     testSetup();
     pvxs::logger_config_env();
     generalTimeRegisterCurrentProvider("test", 1, &testTimeCurrent);
@@ -1040,6 +1094,7 @@ MAIN(testqsingle)
         testGetPut64();
         testPutProc();
         testPutLog();
+        testSecurityLoggerPfield();
         {
             TestClient mctxt;
             testMonitorAI(mctxt);

--- a/test/testqsingle.db
+++ b/test/testqsingle.db
@@ -65,3 +65,7 @@ record(longin, "test:nsec") {
     field(VAL , "100")
     info(Q:time:tag, "nsec:lsb:8")
 }
+
+# Dedicated record providing a dbChannel for the SecurityLogger
+# addr.pfield restore unit test (testSecurityLoggerPfield).
+record(longout, "test:pfield") {}


### PR DESCRIPTION
This series fixes seven independent correctness issues in QSRV (the IOC server), the access-security logging path, and the monitor pipeline. Each issue is a separate commit with its own regression test; every new assertion was confirmed to fail before its fix and pass after.

### Fixes

**1. `SecurityLogger` never restores `dbChannel::addr.pfield`** (`ioc/securitylogger.h`)
The data-carrying constructor saved `pDbChannel->addr.pfield` into `pfieldsave` but never set `pchan`, so both restore sites (constructor body and destructor), guarded by `if(pchan)`, were dead for every constructed logger. As the comment (and epics-base#474 / caPutLog#23) notes, `asTrapWrite` callbacks may clobber `pfield`; without the restore the saved pointer is dropped. Fixed by initializing `pchan(pDbChannel)` in the constructor init list, before the `asTrapWriteWithData` call.

**2. Non-atomic group put uses the wrong `SecurityClient` after a channel-less field** (`ioc/groupsource.cpp`)
`securityClients` is sized to `group.fields.size()` and indexed by the full field index, but the non-atomic put loop advanced `fieldIndex` only after a channel-backed field while `continue`-ing over channel-less `Structure`/`Const` fields (which sort first via the minimum putorder). After the first channel-less field the index drifts, so a write can be authorized/denied/logged with another field's security client. Fixed by advancing `fieldIndex` for every field and skipping only the DB op when `field.value` is null — matching the population, preprocessing, and atomic-put paths.

**3. Non-atomic group get omits `Const` fields** (`ioc/groupsource.cpp`)
The atomic get and monitor paths populate `Const` fields from `info.cval`, but the non-atomic get gated each read on `if(pDbChannel && leafNode)`, and `Const` fields have no channel by construction — so a `record[atomic=false]` get returned them at their default instead of the constant. Fixed by mirroring the atomic branch's field selection (skip only `Proc`/`Structure`, read the rest) and taking the per-field lock only when a channel is present.

**4. Monitor stats report the squash count in `nQueue`** (`src/servermon.cpp`)
`stats()` set `stat.nQueue = queue.size()` then immediately overwrote it with `nSquash`, and never set `stat.nSquash`. Fixed the second assignment to `stat.nSquash = mon->nSquash`.

**5. `ackAny` percentage is treated as a multiplier** (`src/servermon.cpp`, `src/clientmon.cpp`)
A percentage like `"50%"` was clamped to `[0, 100]` then used directly as `ackAt = percent * limit`, so 50% of a queue of 4 became 200 → clamped to the full queue; any percentage ≥ 1% collapsed to "ack at full queue". Fixed both parse paths to compute `percent / 100.0 * queueSize`. (The existing `ackAt == 0` guard and `max(1, …)` clamp still handle percentages too small to express on a short queue.)

**6. pvaLink never publishes the remote `timeStamp.userTag`** (`ioc/pvalink_lset.cpp`)
The monitor cache captures `timeStamp.userTag` into `fld_usertag`, and `snap_time` is updated from `fld_seconds`/`fld_nanoseconds`, but `snap_tag` (returned via `getTimeStampTag`) was never assigned from `fld_usertag` and stayed at its initial 0. Fixed by updating `snap_tag` from `fld_usertag` in the same snapshot block, with a 0 fallback.

**7. pvaLink type-change cleanup leaves `fld_seconds` stale** (`ioc/pvalink_link.cpp`)
`onTypeChange()` cleared the cached metadata fields but omitted `fld_seconds` (and assigned `fld_severity` twice). On a structure→non-structure type change, `pvaGetValue()` could keep using the old seconds, producing stale record timestamps. Fixed by clearing `fld_seconds` together with the other cached fields.

### Testing

Built against EPICS Base 7.0 (darwin-aarch64); each new test fails on `master` and passes with its commit.

- `testqsingle` — #1
- `testqgroup` — #2, #3
- `testmonpipe` — #4, #5
- `testpvalink` — #6, #7
