### PR TITLE
codec, client: bound decode and reject pre-INIT monitor data

### DIFF
--- a/src/clientmon.cpp
+++ b/src/clientmon.cpp
@@ -500,7 +500,47 @@ void Connection::handle_MONITOR()
                        peerName.c_str(), unsigned(ioid));
             return;
         }
+    }
 
+    // Validate the message against operation state *before* decoding any
+    // payload below.  The data branch dereferences info->fl, which stays null
+    // until the INIT reply has been processed, so a data message arriving while
+    // the monitor is still Creating must be rejected here -- not after the
+    // dereference.  Validating first makes "payload is decoded only after a
+    // successful INIT" hold by construction.
+
+    std::shared_ptr<OperationBase> op;
+    SubscriptionImpl* mon = nullptr;
+    if(M.good() && info) {
+        op = info->handle.lock();
+        if(!op) {
+            // assume op has already sent CMD_DESTROY_REQUEST
+            log_debug_printf(io, "Server %s ignoring stale cmd%02x ioid %u\n",
+                             peerName.c_str(), CMD_MONITOR, unsigned(ioid));
+            return;
+        }
+
+        if(uint8_t(op->op)!=CMD_MONITOR) {
+            // peer mixes up IOID and operation type
+            M.fault(__FILE__, __LINE__);
+
+        } else {
+            mon = static_cast<SubscriptionImpl*>(op.get());
+
+            // check that subcmd is as expected based on operation state
+            if((mon->state==SubscriptionImpl::Creating) && init) {
+
+            } else if((mon->state==SubscriptionImpl::Idle) && !init) {
+
+            } else if((mon->state==SubscriptionImpl::Running) && !init) {
+
+            } else {
+                M.fault(__FILE__, __LINE__);
+            }
+        }
+    }
+
+    if(M.good()) {
         if(!sts.isSuccess()) {
 
         } else if(init) {
@@ -561,39 +601,6 @@ void Connection::handle_MONITOR()
                     servSquash = true;
                     break;
                 }
-            }
-        }
-    }
-
-    // validate received message against operation state
-
-    std::shared_ptr<OperationBase> op;
-    SubscriptionImpl* mon = nullptr;
-    if(M.good() && info) {
-        op = info->handle.lock();
-        if(!op) {
-            // assume op has already sent CMD_DESTROY_REQUEST
-            log_debug_printf(io, "Server %s ignoring stale cmd%02x ioid %u\n",
-                             peerName.c_str(), CMD_MONITOR, unsigned(ioid));
-            return;
-        }
-
-        if(uint8_t(op->op)!=CMD_MONITOR) {
-            // peer mixes up IOID and operation type
-            M.fault(__FILE__, __LINE__);
-
-        } else {
-            mon = static_cast<SubscriptionImpl*>(op.get());
-
-            // check that subcmd is as expected based on operation state
-            if((mon->state==SubscriptionImpl::Creating) && init) {
-
-            } else if((mon->state==SubscriptionImpl::Idle) && !init) {
-
-            } else if((mon->state==SubscriptionImpl::Running) && !init) {
-
-            } else {
-                M.fault(__FILE__, __LINE__);
             }
         }
     }

--- a/src/dataencode.cpp
+++ b/src/dataencode.cpp
@@ -9,6 +9,7 @@
 
 #include <cassert>
 
+#include <algorithm>
 #include <stdexcept>
 #include <functional>
 #include <ostream>
@@ -154,7 +155,10 @@ void from_wire(Buffer& buf, std::vector<FieldDesc>& descs, TypeStore& cache, uns
             {
                 auto& fld = descs.back();
 
-                fld.miter.reserve(nfld.size);
+                // Clamp the speculative reserve to the bytes that could remain:
+                // each child costs at least one wire byte, so a larger nfld is
+                // malformed and the child loop below will fault on it.
+                fld.miter.reserve(std::min(size_t(nfld.size), buf.maxAvail()));
             }
 
             auto& cdescs = code.code==TypeCode::Struct ? descs : descs.back().members;
@@ -625,6 +629,10 @@ void from_wire_field(Buffer& buf, TypeStore& ctxt,  const FieldDesc* desc, const
         case TypeCode::StructA:{
             Size alen{};
             from_wire(buf, alen);
+            if(alen.size > buf.maxAvail()) { // each element needs >=1 validity byte
+                buf.fault(__FILE__, __LINE__);
+                return;
+            }
             shared_array<Value> arr(alen.size);
             std::shared_ptr<const FieldDesc> etype(store->top->desc,
                                                    &desc->members[0]); // alias
@@ -642,6 +650,10 @@ void from_wire_field(Buffer& buf, TypeStore& ctxt,  const FieldDesc* desc, const
         case TypeCode::UnionA: {
             Size alen{};
             from_wire(buf, alen);
+            if(alen.size > buf.maxAvail()) { // each element needs >=1 validity byte
+                buf.fault(__FILE__, __LINE__);
+                return;
+            }
             shared_array<Value> arr(alen.size);
             auto cdesc = &desc->members[0];
 
@@ -674,6 +686,10 @@ void from_wire_field(Buffer& buf, TypeStore& ctxt,  const FieldDesc* desc, const
         case TypeCode::AnyA:{
             Size alen{};
             from_wire(buf, alen);
+            if(alen.size > buf.maxAvail()) { // each element needs >=1 validity byte
+                buf.fault(__FILE__, __LINE__);
+                return;
+            }
             shared_array<Value> arr(alen.size);
 
             for(auto& elem : arr) {

--- a/src/dataencode.cpp
+++ b/src/dataencode.cpp
@@ -66,9 +66,17 @@ void to_wire(Buffer& buf, const FieldDesc* cur)
     }
 }
 
+// Maximum structural nesting depth accepted by the (de)serializer.  One global
+// bound shared by the type-description builder and the value decoder: nested
+// Any/Union/array-of-compound each cost one level, and depth flows across the Any
+// boundary (the inner type is read at depth+1), so "total nesting <= this" holds by
+// construction and bounds both the recursion stack and per-message node allocation.
+// PVA structures in practice are only a few levels deep.
+static constexpr unsigned maxNestingDepth = 20u;
+
 void from_wire(Buffer& buf, std::vector<FieldDesc>& descs, TypeStore& cache, unsigned depth)
 {
-    if(!buf.good() || depth>20) {
+    if(!buf.good() || depth>maxNestingDepth) {
         buf.fault(__FILE__, __LINE__);
         return;
     }
@@ -448,8 +456,18 @@ T from_wire_as(Buffer& buf)
 }
 
 static
-void from_wire_field(Buffer& buf, TypeStore& ctxt,  const FieldDesc* desc, const std::shared_ptr<FieldStorage>& store)
+void from_wire_field(Buffer& buf, TypeStore& ctxt,  const FieldDesc* desc, const std::shared_ptr<FieldStorage>& store, unsigned depth)
 {
+    // Enforce the shared nesting bound on the value-decode call chain (this funnels
+    // every recursive descent: Union/Any/array-of-compound re-enter via
+    // from_wire_full -> from_wire_field).  Without it a chain of Any *values* (each a
+    // single 0x82 byte) recurses once per byte and exhausts the thread stack
+    // (SIGSEGV, uncatchable).  depth flows across the Any boundary into the inner
+    // type read below, so type and value nesting share one global count.
+    if(depth>maxNestingDepth) {
+        buf.fault(__FILE__, __LINE__);
+        return;
+    }
     switch(store->code) {
     case StoreType::Null:
         switch(desc->code.code) {
@@ -459,7 +477,7 @@ void from_wire_field(Buffer& buf, TypeStore& ctxt,  const FieldDesc* desc, const
                 auto cdesc = desc + off;
                 std::shared_ptr<FieldStorage> cstore(store, store.get()+off); // TODO avoid shared_ptr/aliasing here
                 if(cdesc->code!=TypeCode::Struct) {
-                    from_wire_field(buf, ctxt, cdesc, cstore);
+                    from_wire_field(buf, ctxt, cdesc, cstore, depth);
                     cstore->valid = true;
                 }
             }
@@ -530,7 +548,7 @@ void from_wire_field(Buffer& buf, TypeStore& ctxt,  const FieldDesc* desc, const
                                                        &desc->members[desc->miter[select.index()].second]); // alias
                 fld = Value::Helper::build(stype, store, desc);
 
-                from_wire_full(buf, ctxt, fld);
+                from_wire_full(buf, ctxt, fld, depth+1);
                 return;
 
             } else { // invalid selection
@@ -542,7 +560,7 @@ void from_wire_field(Buffer& buf, TypeStore& ctxt,  const FieldDesc* desc, const
         case TypeCode::Any: {
             auto descs(std::make_shared<std::vector<FieldDesc>>());
 
-            from_wire(buf, *descs, ctxt);
+            from_wire(buf, *descs, ctxt, depth+1);
             if(!buf.good())
                 return;
 
@@ -554,7 +572,7 @@ void from_wire_field(Buffer& buf, TypeStore& ctxt,  const FieldDesc* desc, const
                 std::shared_ptr<const FieldDesc> stype(descs, descs->data()); // alias
                 fld = Value::Helper::build(stype);
 
-                from_wire_full(buf, ctxt, fld);
+                from_wire_full(buf, ctxt, fld, depth+1);
                 return;
 
             }
@@ -614,7 +632,7 @@ void from_wire_field(Buffer& buf, TypeStore& ctxt,  const FieldDesc* desc, const
                 if(from_wire_as<uint8_t>(buf)!=0) { // strictly 1 or 0
                     elem = Value::Helper::build(etype, store, desc);
 
-                    from_wire_full(buf, ctxt, elem);
+                    from_wire_full(buf, ctxt, elem, depth+1);
                 }
             }
 
@@ -640,7 +658,7 @@ void from_wire_field(Buffer& buf, TypeStore& ctxt,  const FieldDesc* desc, const
                                                                &cdesc->members[cdesc->miter[select.index()].second]); // alias
                         elem = Value::Helper::build(stype, store, desc);
 
-                        from_wire_full(buf, ctxt, elem);
+                        from_wire_full(buf, ctxt, elem, depth+1);
 
                     } else {
                         // invalid selector
@@ -662,7 +680,7 @@ void from_wire_field(Buffer& buf, TypeStore& ctxt,  const FieldDesc* desc, const
                 if(from_wire_as<uint8_t>(buf)!=0) { // strictly 1 or 0
                     auto descs(std::make_shared<std::vector<FieldDesc>>());
 
-                    from_wire(buf, *descs, ctxt);
+                    from_wire(buf, *descs, ctxt, depth+1);
                     if(!buf.good())
                         return;
 
@@ -671,7 +689,7 @@ void from_wire_field(Buffer& buf, TypeStore& ctxt,  const FieldDesc* desc, const
                         std::shared_ptr<const FieldDesc> stype(descs, descs->data()); // alias
                         elem = Value::Helper::build(stype, store, desc);
 
-                        from_wire_full(buf, ctxt, elem);
+                        from_wire_full(buf, ctxt, elem, depth+1);
                     }
                 }
             }
@@ -689,14 +707,14 @@ void from_wire_field(Buffer& buf, TypeStore& ctxt,  const FieldDesc* desc, const
     buf.fault(__FILE__, __LINE__);
 }
 
-void from_wire_full(Buffer& buf, TypeStore& ctxt, Value& val)
+void from_wire_full(Buffer& buf, TypeStore& ctxt, Value& val, unsigned depth)
 {
     assert(!!val);
 
-    from_wire_field(buf, ctxt, Value::Helper::desc(val), Value::Helper::store(val));
+    from_wire_field(buf, ctxt, Value::Helper::desc(val), Value::Helper::store(val), depth);
 }
 
-void from_wire_valid(Buffer& buf, TypeStore& ctxt, Value& val)
+void from_wire_valid(Buffer& buf, TypeStore& ctxt, Value& val, unsigned depth)
 {
     auto desc = Value::Helper::desc(val);
     auto store = Value::Helper::store(val);
@@ -720,7 +738,7 @@ void from_wire_valid(Buffer& buf, TypeStore& ctxt, Value& val)
     {
         std::shared_ptr<FieldStorage> cstore(store, store.get()+bit);
         auto cdesc = desc + bit;
-        from_wire_field(buf, ctxt, cdesc, cstore);
+        from_wire_field(buf, ctxt, cdesc, cstore, depth);
         cstore->valid = true;
         bit = valid.findSet(bit + cdesc->size());
     }

--- a/src/dataimpl.h
+++ b/src/dataimpl.h
@@ -178,12 +178,14 @@ PVXS_API
 void from_wire_type(Buffer& buf, TypeStore& ctxt, Value& val);
 
 //! deserialize full Value
+//! depth bounds value-decode recursion (nested Any/Union/array-of-compound),
+//! mirroring the type-description builder's depth guard in from_wire(.., depth).
 PVXS_API
-void from_wire_full(Buffer& buf, TypeStore& ctxt, Value& val);
+void from_wire_full(Buffer& buf, TypeStore& ctxt, Value& val, unsigned depth=0);
 
 //! deserialize BitMask and partial Value
 PVXS_API
-void from_wire_valid(Buffer& buf, TypeStore& ctxt, Value& val);
+void from_wire_valid(Buffer& buf, TypeStore& ctxt, Value& val, unsigned depth=0);
 
 //! deserialize type description and full value (a la. pvRequest)
 PVXS_API

--- a/src/evhelper.cpp
+++ b/src/evhelper.cpp
@@ -991,6 +991,15 @@ bool EvOutBuf::refill(size_t more)
 
 EvInBuf::~EvInBuf() { refill(0); }
 
+size_t EvInBuf::maxAvail() const
+{
+    // size() is only the current pulled-up window; the remainder of the
+    // (already fully accumulated) message body stays in backing until the
+    // next refill() drains the bytes consumed so far (pos-base).
+    size_t consumed = base ? size_t(pos - base) : 0u;
+    return evbuffer_get_length(backing) - consumed;
+}
+
 bool EvInBuf::refill(size_t needed)
 {
     if(err) return false;

--- a/src/pvaproto.h
+++ b/src/pvaproto.h
@@ -86,6 +86,14 @@ public:
     EPICS_ALWAYS_INLINE bool empty() const { return limit==pos; }
     EPICS_ALWAYS_INLINE size_t size() const { return limit-pos; }
 
+    // Upper bound on the number of bytes which could still be decoded from this
+    // buffer.  Unlike size() (only the current contiguous window), this also
+    // counts bytes not yet pulled into the window.  Used to bound an allocation
+    // sized from an untrusted wire count before the matching bytes are read:
+    // every element/child costs at least one wire byte, so a count exceeding
+    // maxAvail() cannot be substantiated by the remaining body.
+    virtual size_t maxAvail() const { return size(); }
+
     // the following assume good()==true && !empty()
     EPICS_ALWAYS_INLINE uint8_t& operator[](size_t i) const { return pos[i]; }
     EPICS_ALWAYS_INLINE void push(uint8_t v) { *pos++ = v; }
@@ -162,6 +170,7 @@ public:
     virtual ~EvInBuf();
 
     virtual bool refill(size_t more) override final;
+    virtual size_t maxAvail() const override final;
 };
 
 // assumes prior buf.ensure(M) where M>=N
@@ -526,6 +535,14 @@ void from_wire(Buffer& buf, shared_array<const void>& varr)
 {
     Size slen{};
     from_wire(buf, slen);
+    // Reject a count the remaining body cannot substantiate before allocating:
+    // a fixed-size POD element needs sizeof(C) wire bytes, a variable element
+    // (string) at least one.
+    const size_t minElemBytes = std::is_pod<C>::value ? sizeof(C) : 1u;
+    if(slen.size > buf.maxAvail()/minElemBytes) {
+        buf.fault(__FILE__, __LINE__);
+        return;
+    }
     shared_array<E> arr(slen.size);
 
     if(std::is_pod<C>::value) {

--- a/test/Makefile
+++ b/test/Makefile
@@ -83,6 +83,10 @@ TESTPROD_HOST += testmonpipe
 testmonpipe_SRCS += testmonpipe.cpp
 TESTS += testmonpipe
 
+TESTPROD_HOST += testclientconn
+testclientconn_SRCS += testclientconn.cpp
+TESTS += testclientconn
+
 TESTPROD_HOST += testput
 testput_SRCS += testput.cpp
 TESTS += testput

--- a/test/testclientconn.cpp
+++ b/test/testclientconn.cpp
@@ -1,0 +1,337 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * pvxs is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+
+// Drive a real client::Context against a hand-rolled "server" which speaks
+// just enough of the PVA wire protocol to reach a given operation state, then
+// injects a crafted frame the real server state machine would never send.
+// Used to exercise client-side connection/operation state-machine handling
+// against a hostile or buggy peer.
+
+#include <atomic>
+#include <functional>
+#include <vector>
+
+#include <testMain.h>
+#include <epicsUnitTest.h>
+#include <epicsEvent.h>
+#include <epicsThread.h>
+
+#include <osiSock.h>
+#include <event2/util.h>
+
+#include <pvxs/unittest.h>
+#include <pvxs/log.h>
+#include <pvxs/client.h>
+
+#include "evhelper.h"   // pulls in pvaproto.h (Header, VectorOutBuf, to_wire, ...)
+
+namespace {
+using namespace pvxs;
+
+// blocking send of exactly n bytes
+bool sendn(evutil_socket_t fd, const void* buf, size_t n)
+{
+    auto p = static_cast<const char*>(buf);
+    while(n) {
+        int r = ::send(fd, p, n, 0);
+        if(r <= 0)
+            return false;
+        p += r;
+        n -= size_t(r);
+    }
+    return true;
+}
+
+// blocking recv of exactly n bytes.  false on EOF or error.
+bool recvn(evutil_socket_t fd, void* buf, size_t n)
+{
+    auto p = static_cast<char*>(buf);
+    while(n) {
+        int r = ::recv(fd, p, n, 0);
+        if(r <= 0)
+            return false;
+        p += r;
+        n -= size_t(r);
+    }
+    return true;
+}
+
+// Build one application/control frame (always little-endian body, Server flag
+// set) and write it.  bodyfn appends the body; the 8-byte header is filled in
+// afterwards with the resulting length.
+bool sendFrame(evutil_socket_t fd, uint8_t cmd, uint8_t extraFlags,
+               const std::function<void(VectorOutBuf&)>& bodyfn)
+{
+    std::vector<uint8_t> msg(256, 0u); // larger than any frame here, so no realloc
+    VectorOutBuf M(false, msg);        // false => LSB
+    M.skip(8, __FILE__, __LINE__);     // placeholder for header
+    if(bodyfn)
+        bodyfn(M);
+    if(!M.good())
+        return false;
+    auto pktlen = M.save() - msg.data();
+
+    FixedBuf H(false, msg.data(), 8);
+    to_wire(H, Header{cmd, uint8_t(pva_flags::Server | extraFlags), uint32_t(pktlen - 8)});
+    if(!H.good())
+        return false;
+
+    return sendn(fd, msg.data(), size_t(pktlen));
+}
+
+// Receive one whole frame.  Honors the peer's MSB flag for the length field and
+// reports it so the body can be decoded in the same byte order.  Control
+// messages carry no body.  false on EOF or error.
+bool recvFrame(evutil_socket_t fd, uint8_t& cmd, bool& be, std::vector<uint8_t>& body)
+{
+    uint8_t hdr[8];
+    if(!recvn(fd, hdr, sizeof(hdr)))
+        return false;
+    if(hdr[0] != 0xca)
+        return false;
+    be = hdr[2] & pva_flags::MSB;
+    cmd = hdr[3];
+
+    if(hdr[2] & pva_flags::Control) {
+        body.clear();
+        return true; // control frames are header-only
+    }
+
+    FixedBuf L(be, hdr + 4, 4);
+    uint32_t len = 0;
+    from_wire(L, len);
+    if(!L.good())
+        return false;
+    body.resize(len);
+    if(len && !recvn(fd, body.data(), len))
+        return false;
+    return true;
+}
+
+enum MockOutcome {
+    Pending,
+    BadHandshake,   // peer diverged from the expected handshake
+    Survived,       // bad frame injected, client closed the connection cleanly
+    Unexpected,     // client sent more data instead of disconnecting
+    NoReaction,     // client neither closed nor responded (kept the bad op alive)
+};
+
+struct Mock : public epicsThreadRunable {
+    evsocket listener;
+    uint16_t port = 0;
+    std::atomic<int> outcome{Pending};
+    std::atomic<unsigned> initSubcmd{0xffff};
+    epicsEvent done;
+    epicsThread worker;
+    bool started = false;
+
+    Mock()
+        :listener(AF_INET, SOCK_STREAM, 0, true) // blocking
+        ,worker(*this, "mockpeer", epicsThreadGetStackSize(epicsThreadStackMedium))
+    {
+        SockAddr addr(SockAddr::loopback(AF_INET));
+        listener.bind(addr);
+        listener.listen(1);
+        port = addr.port();
+    }
+
+    ~Mock()
+    {
+        if(started)
+            worker.exitWait();
+    }
+
+    void start() { started = true; worker.start(); }
+
+    void finish(MockOutcome o)
+    {
+        outcome.store(o);
+        done.signal();
+    }
+
+    void run() override final
+    {
+        evutil_socket_t cfd = ::accept(listener.sock, nullptr, nullptr);
+        if(cfd == int(INVALID_SOCKET)) {
+            finish(BadHandshake);
+            return;
+        }
+        // Bound every blocking recv so a client that hangs, stalls the
+        // handshake, or keeps a bad operation alive cannot wedge this thread.
+        // Windows SO_RCVTIMEO wants a DWORD of milliseconds, POSIX a timeval.
+#ifdef _WIN32
+        const uint32_t tmo = 5000u; // ms; 4 bytes == DWORD, no <windows.h> needed
+#else
+        const struct timeval tmo{5, 0};
+#endif
+        setsockopt(cfd, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const char*>(&tmo), sizeof(tmo));
+        MockOutcome o = play(cfd);
+        evutil_closesocket(cfd);
+        finish(o);
+    }
+
+    // Drive the handshake to MONITOR INIT, inject the hostile frame, and report
+    // how the client reacted.
+    MockOutcome play(evutil_socket_t cfd)
+    {
+        uint8_t cmd = 0;
+        bool be = false;
+        std::vector<uint8_t> body;
+
+        // Latch the client's TX byte order to little-endian.
+        if(!sendFrame(cfd, pva_ctrl_msg::SetEndian, pva_flags::Control, nullptr))
+            return BadHandshake;
+
+        // CONNECTION_VALIDATION: serverReceiveBufferSize, introspectionMax, then
+        // a single offered auth method.
+        if(!sendFrame(cfd, CMD_CONNECTION_VALIDATION, 0u, [](VectorOutBuf& M){
+                          to_wire(M, uint32_t(0x10000));
+                          to_wire(M, uint16_t(0x7fff));
+                          to_wire(M, Size{1});
+                          to_wire(M, "anonymous");
+                      }))
+            return BadHandshake;
+
+        // client's CONNECTION_VALIDATION reply (auth selection + creds) -- drain
+        if(!recvFrame(cfd, cmd, be, body) || cmd != CMD_CONNECTION_VALIDATION)
+            return BadHandshake;
+
+        if(!sendFrame(cfd, CMD_CONNECTION_VALIDATED, 0u, [](VectorOutBuf& M){
+                          to_wire(M, Status{Status::Ok});
+                      }))
+            return BadHandshake;
+
+        // client's CREATE_CHANNEL: count(u16), then cid(u32) + name(string)
+        if(!recvFrame(cfd, cmd, be, body) || cmd != CMD_CREATE_CHANNEL)
+            return BadHandshake;
+        uint32_t cid = 0;
+        {
+            FixedBuf B(be, body);
+            uint16_t count = 0;
+            from_wire(B, count);
+            from_wire(B, cid);
+            if(!B.good() || count != 1u)
+                return BadHandshake;
+        }
+
+        // accept the channel
+        if(!sendFrame(cfd, CMD_CREATE_CHANNEL, 0u, [cid](VectorOutBuf& M){
+                          to_wire(M, cid);
+                          to_wire(M, uint32_t(1u)); // sid
+                          to_wire(M, Status{Status::Ok});
+                      }))
+            return BadHandshake;
+
+        // client's MONITOR INIT: sid(u32), ioid(u32), subcmd(u8=0x08), pvRequest
+        if(!recvFrame(cfd, cmd, be, body) || cmd != CMD_MONITOR)
+            return BadHandshake;
+        uint32_t ioid = 0;
+        {
+            FixedBuf B(be, body);
+            uint32_t sid = 0;
+            from_wire(B, sid);
+            from_wire(B, ioid);
+            if(!B.good() || body.size() < 9)
+                return BadHandshake;
+            // subcmd is a single byte (byte order irrelevant); read it directly
+            // rather than via from_wire<uint8_t>, which trips a spurious
+            // -Wmaybe-uninitialized in this inlining context on some GCC versions.
+            initSubcmd.store(body[8]);
+        }
+
+        // Hostile frame: a MONITOR *data* update (subcmd has neither INIT(0x08)
+        // nor a status), arriving while the subscription is still Creating --
+        // before any INIT reply.  A correct client must reject this without
+        // dereferencing the not-yet-allocated per-request free list.
+        if(!sendFrame(cfd, CMD_MONITOR, 0u, [ioid](VectorOutBuf& M){
+                          to_wire(M, ioid);
+                          to_wire(M, uint8_t(0x00));
+                      }))
+            return BadHandshake;
+
+        // A correct client treats this as a protocol violation and drops the
+        // connection: our next read sees EOF.  (If the client crashed instead,
+        // this whole process is gone and the test never reports.)
+        uint8_t junk[64];
+        int r = ::recv(cfd, reinterpret_cast<char*>(junk), sizeof(junk), 0);
+        if(r == 0)
+            return Survived;     // EOF: client dropped the connection
+        if(r > 0)
+            return Unexpected;   // client said something instead of disconnecting
+        return NoReaction;       // recv timed out: connection still open, idle
+    }
+};
+
+void testMonitorDataBeforeInit()
+{
+    testDiag("%s", __func__);
+
+    // Rejecting the hostile frame is the correct outcome, and it logs CRIT on
+    // pvxs.client.io -- the same path every peer protocol violation takes.  CI
+    // runs with _PVXS_ABORT_ON_CRIT=1, which turns that expected CRIT into an
+    // abort().  Drop this logger below Crit so the expected rejection does not
+    // abort the test; the client still disconnects, which is what we check.
+    logger_level_set("pvxs.client.io", int(Level::Crit) - 1);
+
+    Mock mock;
+    testDiag("mock peer listening on 127.0.0.1:%u", unsigned(mock.port));
+
+    client::Config cconf;
+    cconf.autoAddrList = false;     // no broadcast search; we force a direct server
+    cconf.addressList.clear();
+    auto cli(cconf.build());
+
+    mock.start();
+
+    std::string server("127.0.0.1:");
+    server += std::to_string(mock.port);
+
+    auto sub = cli.monitor("hostile")
+            .server(server)
+            .maskConnected(false)
+            .maskDisconnected(false)
+            .event([](client::Subscription&){})
+            .exec();
+
+    bool signaled = mock.done.wait(20.0);
+
+    if(!signaled) {
+        testFail("timed out waiting for mock peer (client may be hung)");
+    } else {
+        switch(mock.outcome.load()) {
+        case Survived:
+            testPass("client rejected pre-INIT MONITOR data frame and disconnected without crashing");
+            break;
+        case BadHandshake:
+            testFail("mock handshake diverged before injection (test harness, not the client)");
+            break;
+        case Unexpected:
+            testFail("client answered the bad frame instead of rejecting it");
+            break;
+        case NoReaction:
+            testFail("client kept the connection open instead of rejecting the bad frame");
+            break;
+        default:
+            testFail("mock peer reported no outcome");
+        }
+    }
+    testDiag("observed MONITOR INIT subcmd 0x%02x", mock.initSubcmd.load());
+
+    sub.reset();
+}
+
+} // namespace
+
+int main(int argc, char* argv[])
+{
+    SockAttach attach;
+    testPlan(1);
+    testSetup();
+    pvxs::logger_config_env();
+    testMonitorDataBeforeInit();
+    cleanup_for_valgrind();
+    return testDone();
+}

--- a/test/testxcode.cpp
+++ b/test/testxcode.cpp
@@ -9,6 +9,8 @@
 
 #include <string>
 
+#include <event2/buffer.h>
+
 #include <pvxs/util.h>
 #include <pvxs/unittest.h>
 #include <pvxs/nt.h>
@@ -1195,6 +1197,79 @@ void testRegressDeepAny()
     testFalse(buf.good())<<" deeply-nested Any must fault, not recurse without bound";
 }
 
+// An array length is a 32-bit count the peer fully controls.  The decoder must
+// not size an allocation from it before the matching bytes are read: every
+// element costs at least one wire byte, so a count larger than the remaining
+// body is malformed.  Without the bound the array is pre-sized to the bogus
+// count (default-constructing every element -- megabytes to many GiB) and that
+// oversized array is what the field is left holding after the short read is
+// finally noticed.  The fix faults before allocating, so the field stays empty.
+// A small count keeps the unbounded path cheap enough to observe its result
+// directly: the field length must be 0, not the claimed count.
+void testRegressHugeCount()
+{
+    testDiag("%s", __func__);
+
+    {
+        // Struct{ value: Int32A } whose value claims 1000 elements but carries
+        // only one (four payload bytes).
+        std::vector<uint8_t> msg{0x80, 0x00, 0x01, 0x05, 'v','a','l','u','e', 0x2a,
+                                 0xfe, 0xe8, 0x03, 0x00, 0x00,
+                                 0x01, 0x02, 0x03, 0x04};
+        TypeStore ctxt;
+        Value val;
+        FixedBuf buf(false, msg);
+        from_wire_type_value(buf, ctxt, val);
+        testEq(val["value"].as<shared_array<const void>>().size(), 0u)
+                <<" Int32A claiming 1000 elements over a 1-element body must not be allocated";
+    }
+
+    {
+        // Struct{ value: StructA-of-empty-Struct } whose value claims 1000
+        // elements but carries none.
+        std::vector<uint8_t> msg{0x80, 0x00, 0x01, 0x05, 'v','a','l','u','e',
+                                 0x88, 0x80, 0x00, 0x00,
+                                 0xfe, 0xe8, 0x03, 0x00, 0x00};
+        TypeStore ctxt;
+        Value val;
+        FixedBuf buf(false, msg);
+        from_wire_type_value(buf, ctxt, val);
+        testEq(val["value"].as<shared_array<const void>>().size(), 0u)
+                <<" StructA claiming 1000 elements over an empty body must not be allocated";
+    }
+}
+
+// The decode bound above is computed from Buffer::maxAvail().  For a segmented
+// EvInBuf that is *not* the same as size(): size() is only the currently
+// pulled-up window, while maxAvail() must report the whole remaining body still
+// in backing.  Otherwise a legitimate large array delivered across segments
+// would be falsely rejected.  Force two physical segments (the first larger than
+// the pull-up minimum so it is the whole window) and check maxAvail() spans both.
+void testRegressMaxAvail()
+{
+    testDiag("%s", __func__);
+
+    std::vector<uint8_t> seg1(8192u, 0u), seg2(256u, 0u);
+
+    evbuffer *evb = evbuffer_new();
+    // add_reference keeps seg1 a distinct chunk so the window stops at its end.
+    evbuffer_add_reference(evb, seg1.data(), seg1.size(), nullptr, nullptr);
+    evbuffer_add(evb, seg2.data(), seg2.size());
+
+    {
+        EvInBuf M(true, evb, 16);
+        testTrue(M.good())<<" segmented buffer usable";
+        testEq(M.maxAvail(), seg1.size()+seg2.size())<<" maxAvail counts the whole body";
+        testTrue(M.size() < M.maxAvail())<<" window is only the first segment";
+
+        uint32_t v = 0;
+        from_wire(M, v); // consume four bytes
+        testEq(M.maxAvail(), seg1.size()+seg2.size()-4u)<<" maxAvail tracks bytes consumed";
+    }
+
+    evbuffer_free(evb);
+}
+
 // test the common case for a pvRequest of caching an empty Struct
 void testEmptyRequest()
 {
@@ -1275,7 +1350,7 @@ void testPartialXCode()
 
 MAIN(testxcode)
 {
-    testPlan(151);
+    testPlan(157);
     testSetup();
     testDeserializeString();
     testSerialize1();
@@ -1292,6 +1367,8 @@ MAIN(testxcode)
     testRegressCNEN();
     testRegressBadBitMask();
     testRegressDeepAny();
+    testRegressHugeCount();
+    testRegressMaxAvail();
     testBadFieldName();
     testEmptyRequest();
     testPartialXCode();

--- a/test/testxcode.cpp
+++ b/test/testxcode.cpp
@@ -1176,6 +1176,25 @@ void testRegressBadBitMask()
     }
 }
 
+// A run of TypeCode::Any (0x82) leaf bytes encodes an Any value whose content is
+// itself an Any, repeated.  The value decoder must be bounded by its depth guard
+// and fault, instead of recursing once per byte (from_wire_field -> from_wire_full
+// -> from_wire_field -> ...) and exhausting the thread stack.  Reaching the
+// assertion at all is the regression: without the bound this overflows the stack
+// and crashes the process (SIGSEGV is not a std::exception, so it is uncatchable).
+void testRegressDeepAny()
+{
+    testDiag("%s", __func__);
+
+    std::vector<uint8_t> msg(1000000u, 0x82u); // 0x82 == TypeCode::Any
+
+    TypeStore ctxt;
+    Value val;
+    FixedBuf buf(false, msg);
+    from_wire_type_value(buf, ctxt, val);
+    testFalse(buf.good())<<" deeply-nested Any must fault, not recurse without bound";
+}
+
 // test the common case for a pvRequest of caching an empty Struct
 void testEmptyRequest()
 {
@@ -1256,7 +1275,7 @@ void testPartialXCode()
 
 MAIN(testxcode)
 {
-    testPlan(150);
+    testPlan(151);
     testSetup();
     testDeserializeString();
     testSerialize1();
@@ -1272,6 +1291,7 @@ MAIN(testxcode)
     testRegressRedundantBitMask();
     testRegressCNEN();
     testRegressBadBitMask();
+    testRegressDeepAny();
     testBadFieldName();
     testEmptyRequest();
     testPartialXCode();


### PR DESCRIPTION
Thanks for merging the earlier fixes. Three more I ran into while reading the
decode and client monitor paths, all remote-triggerable crashes. Numbers 1 and
2 are reachable during CONNECTION_VALIDATION, before auth.

**1. codec: bound value-decode recursion**
The depth guard in `from_wire()` is reset every time an `Any` *value* is decoded
(the inner type is read with a fresh descriptor), so it never bounds the
value-decode chain. A peer value that is a run of nested `Any` (one `0x82` byte
each) recurses one level per byte and overflows the stack. The SIGSEGV is not a
`std::exception`, so the dispatch try/catch misses it and the whole process
goes down. Fix threads a single `maxNestingDepth` across the `Any` boundary so
the bound holds for both type and value decode.

**2. codec: bound decode allocations to the remaining body**
An array length / struct child count is a peer-supplied 32-bit value, used to
allocate (POD) or default-construct every `Value` (StructA/UnionA/AnyA) before
the element bytes are read. A short frame claiming ~4.29e9 elements commits the
memory first, then faults on the short read. Fix caps the count against the
bytes still available (new `Buffer::maxAvail()`), since each element needs at
least one wire byte.

**3. client: reject a MONITOR data message before the INIT reply**
`handle_MONITOR()` decodes the payload before checking operation state, but
`info->fl` stays null until the INIT reply. A peer that has acked
CREATE_CHANNEL can send a data frame before INIT and the client dereferences
the null free-list. Fix moves the state check ahead of the decode.

Each has a regression test (testxcode, testclientconn). Built and run on
macOS/arm64.
