### PR TITLE
Fix for PVA links to set UTAG/userTag

### DIFF
--- a/ioc/pvalink_lset.cpp
+++ b/ioc/pvalink_lset.cpp
@@ -4,6 +4,7 @@
  * in file LICENSE that is included with this distribution.
  */
 
+#include <cstdint>
 #include <epicsString.h>
 #include <alarm.h>
 #include <recGbl.h>
@@ -407,7 +408,8 @@ long pvaGetValue(DBLINK *plink, short dbrType, void *pbuffer, long *pnRequest) n
         }
 
         if(self->fld_usertag) {
-            self->snap_tag = self->fld_usertag.as<epicsUTag>();
+            // convert to uint32_t to avoid sign extension (Normative Types defines userTag as 32 bits)
+            self->snap_tag = self->fld_usertag.as<uint32_t>();
         } else {
             self->snap_tag = 0;
         }

--- a/ioc/pvalink_lset.cpp
+++ b/ioc/pvalink_lset.cpp
@@ -267,6 +267,9 @@ long pvaGetValue(DBLINK *plink, short dbrType, void *pbuffer, long *pnRequest) n
                                    self->pfieldname);
             if(self->time) {
                 plink->precord->time = self->snap_time;
+#ifdef DBR_UTAG
+                plink->precord->utag = self->snap_tag;
+#endif
             }
             log_debug_printf(_logger, "%s: %s not valid\n", __func__, self->channelName.c_str());
             return -1;
@@ -432,6 +435,9 @@ long pvaGetValue(DBLINK *plink, short dbrType, void *pbuffer, long *pnRequest) n
 
         if(self->time) {
             plink->precord->time = self->snap_time;
+#ifdef DBR_UTAG
+            plink->precord->utag = self->snap_tag;
+#endif
         }
 
         log_debug_printf(_logger, "%s: %s %s snapalrm=%d,\"%s\" OK\n", __func__, plink->precord->name,
@@ -653,7 +659,7 @@ long pvaPutValueX(DBLINK *plink, short dbrType,
         if(!self->defer) self->lchan->put();
 
         log_debug_printf(_logger, "%s: %s %s %s\n", __func__, plink->precord->name, self->channelName.c_str(), self->lchan->root.valid() ? "valid": "not valid");
-        
+
         return 0;
     }CATCH()
     return -1;

--- a/ioc/pvalink_lset.cpp
+++ b/ioc/pvalink_lset.cpp
@@ -267,7 +267,7 @@ long pvaGetValue(DBLINK *plink, short dbrType, void *pbuffer, long *pnRequest) n
                                    self->pfieldname);
             if(self->time) {
                 plink->precord->time = self->snap_time;
-#ifdef DBR_UTAG
+#if DBR_UTAG
                 plink->precord->utag = self->snap_tag;
 #endif
             }
@@ -435,7 +435,7 @@ long pvaGetValue(DBLINK *plink, short dbrType, void *pbuffer, long *pnRequest) n
 
         if(self->time) {
             plink->precord->time = self->snap_time;
-#ifdef DBR_UTAG
+#if DBR_UTAG
             plink->precord->utag = self->snap_tag;
 #endif
         }

--- a/test/testdata.cpp
+++ b/test/testdata.cpp
@@ -562,7 +562,7 @@ void test_cache_sync()
 
 MAIN(testdata)
 {
-    testPlan(193);
+    testPlan(195);
     testSetup();
     testTraverse();
     testAssign();
@@ -610,6 +610,7 @@ MAIN(testdata)
 #endif
     testConvertScalar2<int32_t, uint64_t, int64_t>(-2147483648, 0x80000000, -2147483648);
     testTodoEnd();
+    testConvertScalar2<int32_t, int32_t, uint64_t>(-2147483648, -2147483648, 0xffffffff80000000llu);
     testConvertScalar2<int32_t, uint64_t, int64_t>(0, 0x100000000llu, -0);
     testTodoBegin("UB");
     // test non-finite -> integer casts

--- a/test/testpvalink.cpp
+++ b/test/testpvalink.cpp
@@ -90,7 +90,7 @@ namespace {
         testdbPutArrFieldOk("src:i1.INP$", DBF_CHAR, pv_name.length()+1, pv_name.c_str());
 
         testqsrvWaitForLinkConnected(&i1->inp);
-        
+
         testdbGetFieldEqual("src:i1.VAL", DBF_LONG, 4L); // changing link doesn't automatically process
 
         testdbPutFieldOk("src:i1.PROC", DBF_LONG, 1L);
@@ -98,7 +98,7 @@ namespace {
         testdbGetFieldEqual("src:i1.VAL", DBF_LONG, 2L); // changing link doesn't automatically process
 
     }
-    
+
     void testProc()
     {
 
@@ -646,6 +646,28 @@ namespace {
             testStrMatch(".*\'pva\': testToFromString:str1.*", cap.out());
         }
     }
+
+    // TODO:
+    // void testUTagCopy()
+    // {
+    //     testDiag("==== %s ====", __func__);
+    //     auto serv(ioc::server());
+
+    //     auto source_utag_pv(server::SharedPV::buildReadonly());
+    //     auto top = nt::NTScalar{TypeCode::Int32}.create();
+    //     top["value"] = 42;
+
+    //     // provide a timestamp and a tag value
+    //     Value ts_field(top["timeStamp"]);
+    //     ts_field["secondsPastEpoch"] = 1647059100 + POSIX_TIME_AT_EPICS_EPOCH;
+    //     ts_field["nanoseconds"] = 1;
+    //     ts_field["userTag"] = 1703812500;
+
+    //     source_utag_pv.open(top);
+    //     serv.addPV("source:utag", source_utag_pv);
+
+    //     testqsrvWaitForLinkConnected("target:utag.INP");
+    // }
 
 
 } // namespace

--- a/test/testpvalink.cpp
+++ b/test/testpvalink.cpp
@@ -683,10 +683,10 @@ namespace {
         auto prec(testdbRecordPtr("target:utag"));
         {
             ioc::DBLocker L(prec);
-            testEq(prec->time.secPastEpoch, (0x12345678-POSIX_TIME_AT_EPICS_EPOCH));
-            testEq(prec->time.nsec, 0x10203040);
+            testEq(prec->time.secPastEpoch, (0x12345678u-POSIX_TIME_AT_EPICS_EPOCH));
+            testEq(prec->time.nsec, 0x10203040u);
 #if DBR_UTAG
-            testEq(prec->utag, 0x90010002);
+            testEq(prec->utag, 0x90010002u);
 #else
             testSkip(1, "No UTAG");
 #endif
@@ -698,7 +698,7 @@ namespace {
         testEq(val["timeStamp.secondsPastEpoch"].as<int64_t>(), 0x12345678);
         testEq(val["timeStamp.nanoseconds"].as<int32_t>(), 0x10203040);
 #if DBR_UTAG
-        testEq(val["timeStamp.userTag"].as<int32_t>(), 0x90010002);
+        testEq(val["timeStamp.userTag"].as<int32_t>(), (int32_t)0x90010002);
 #else
         testSkip(1, "No UTAG");
 #endif

--- a/test/testpvalink.cpp
+++ b/test/testpvalink.cpp
@@ -674,7 +674,7 @@ namespace {
             update["value"] = 42;
             update["timeStamp.secondsPastEpoch"] = 0x12345678;
             update["timeStamp.nanoseconds"] = 0x10203040;
-            update["timeStamp.userTag"] = 0x00010002;
+            update["timeStamp.userTag"] = 0x90010002;
             srcutag_shpv.post(update);
             QSrvWaitForLinkUpdate A("target:utag.INP");
         }
@@ -686,7 +686,7 @@ namespace {
             testEq(prec->time.secPastEpoch, (0x12345678-POSIX_TIME_AT_EPICS_EPOCH));
             testEq(prec->time.nsec, 0x10203040);
 #if DBR_UTAG
-            testEq(prec->utag, 0x00010002);
+            testEq(prec->utag, 0x90010002);
 #else
             testSkip(1, "No UTAG");
 #endif
@@ -698,7 +698,7 @@ namespace {
         testEq(val["timeStamp.secondsPastEpoch"].as<int64_t>(), 0x12345678);
         testEq(val["timeStamp.nanoseconds"].as<int32_t>(), 0x10203040);
 #if DBR_UTAG
-        testEq(val["timeStamp.userTag"].as<int32_t>(), 0x00010002);
+        testEq(val["timeStamp.userTag"].as<int32_t>(), 0x90010002);
 #else
         testSkip(1, "No UTAG");
 #endif

--- a/test/testpvalink.cpp
+++ b/test/testpvalink.cpp
@@ -685,7 +685,7 @@ namespace {
             ioc::DBLocker L(prec);
             testEq(prec->time.secPastEpoch, (0x12345678-POSIX_TIME_AT_EPICS_EPOCH));
             testEq(prec->time.nsec, 0x10203040);
-#ifdef DBR_UTAG
+#if DBR_UTAG
             testEq(prec->utag, 0x00010002);
 #else
             testSkip(1, "No UTAG");
@@ -697,7 +697,7 @@ namespace {
         testEq(val["value"].as<int32_t>(), 42);
         testEq(val["timeStamp.secondsPastEpoch"].as<int64_t>(), 0x12345678);
         testEq(val["timeStamp.nanoseconds"].as<int32_t>(), 0x10203040);
-#ifdef DBR_UTAG
+#if DBR_UTAG
         testEq(val["timeStamp.userTag"].as<int32_t>(), 0x00010002);
 #else
         testSkip(1, "No UTAG");

--- a/test/testpvalink.cpp
+++ b/test/testpvalink.cpp
@@ -4,6 +4,7 @@
  * in file LICENSE that is included with this distribution.
  */
 
+#include "epicsTime.h"
 #include <testMain.h>
 #include <epicsExit.h>
 #include <iocsh.h>
@@ -36,6 +37,7 @@
 #include "qsrvpvt.h"
 #include "pvalink.h"
 #include "capturestd.h"
+#include "testioc.h"
 
 using namespace pvxs::ioc;
 using namespace pvxs;
@@ -647,27 +649,63 @@ namespace {
         }
     }
 
-    // TODO:
-    // void testUTagCopy()
-    // {
-    //     testDiag("==== %s ====", __func__);
-    //     auto serv(ioc::server());
+    void testUserTag()
+    {
+        testDiag("==== %s ====", __func__);
+        auto serv(ioc::server());
+        TestClient ctxt;
 
-    //     auto source_utag_pv(server::SharedPV::buildReadonly());
-    //     auto top = nt::NTScalar{TypeCode::Int32}.create();
-    //     top["value"] = 42;
+        // create SharedPV to manipulate userTag
+        auto srcutag_shpv(server::SharedPV::buildReadonly());
+        auto top = nt::NTScalar{TypeCode::Int32}.create();
+        top["value"] = 0;
+        top["timeStamp.secondsPastEpoch"] = 0;
+        top["timeStamp.nanoseconds"] = 0;
+        top["timeStamp.userTag"] = 0;
+        srcutag_shpv.open(top);
+        serv.addPV("source:utag", srcutag_shpv);
 
-    //     // provide a timestamp and a tag value
-    //     Value ts_field(top["timeStamp"]);
-    //     ts_field["secondsPastEpoch"] = 1647059100 + POSIX_TIME_AT_EPICS_EPOCH;
-    //     ts_field["nanoseconds"] = 1;
-    //     ts_field["userTag"] = 1703812500;
+        // routine check if link is connected
+        testqsrvWaitForLinkConnected("target:utag.INP");
 
-    //     source_utag_pv.open(top);
-    //     serv.addPV("source:utag", source_utag_pv);
+        // publish update to be reflected in target:utag
+        {
+            auto update = srcutag_shpv.fetch().cloneEmpty();
+            update["value"] = 42;
+            update["timeStamp.secondsPastEpoch"] = 0x12345678;
+            update["timeStamp.nanoseconds"] = 0x10203040;
+            update["timeStamp.userTag"] = 0x00010002;
+            srcutag_shpv.post(update);
+            QSrvWaitForLinkUpdate A("target:utag.INP");
+        }
 
-    //     testqsrvWaitForLinkConnected("target:utag.INP");
-    // }
+        // Check if record was updated with timeStamp + userTag from link
+        auto prec(testdbRecordPtr("target:utag"));
+        {
+            ioc::DBLocker L(prec);
+            testEq(prec->time.secPastEpoch, (0x12345678-POSIX_TIME_AT_EPICS_EPOCH));
+            testEq(prec->time.nsec, 0x10203040);
+#ifdef DBR_UTAG
+            testEq(prec->utag, 0x00010002);
+#else
+            testSkip(1, "No UTAG");
+#endif
+        }
+
+        // get PV from target:utag and verify if timeStamp is the same from source:utag
+        auto val(ctxt.get("target:utag").exec()->wait(5.0));
+        testEq(val["value"].as<int32_t>(), 42);
+        testEq(val["timeStamp.secondsPastEpoch"].as<int64_t>(), 0x12345678);
+        testEq(val["timeStamp.nanoseconds"].as<int32_t>(), 0x10203040);
+#ifdef DBR_UTAG
+        testEq(val["timeStamp.userTag"].as<int32_t>(), 0x00010002);
+#else
+        testSkip(1, "No UTAG");
+#endif
+        ctxt.close();
+        serv.removePV("source:utag");
+        srcutag_shpv.close();
+    }
 
 
 } // namespace
@@ -676,7 +714,7 @@ extern "C" void testioc_registerRecordDeviceDriver(struct dbBase *);
 
 MAIN(testpvalink)
 {
-    testPlan(106);
+    testPlan(113);
     testSetup();
     pvxs::logger_config_env();
 
@@ -709,6 +747,7 @@ MAIN(testpvalink)
         testEnum();
         testNTNDArray();
         testiocsh();
+        testUserTag();
     }
     catch (std::exception &e)
     {

--- a/test/testpvalink.db
+++ b/test/testpvalink.db
@@ -224,3 +224,8 @@ record(aai, "target:ntndarray_inp") {
     field(NELM, "5")
     field(FTVL, "FLOAT")
 }
+
+record(longin, "target:utag") {
+    field(INP, {pva:{pv:"source:utag", time:true, proc:"CP"}})
+    field(TSE, "-2")
+}

--- a/test/testqgroup.cpp
+++ b/test/testqgroup.cpp
@@ -40,7 +40,7 @@ int testTimeCurrent(epicsTimeStamp *pDest)
 
 void checkUTAG(Value& v, int32_t expect, const char *fld="timeStamp.userTag")
 {
-#ifdef DBR_UTAG
+#if DBR_UTAG
     auto utag = v[fld];
     int32_t tag = -1;
     if(!utag.isMarked() || (tag = utag.as<int32_t>())!=expect)

--- a/test/testqsingle.cpp
+++ b/test/testqsingle.cpp
@@ -56,7 +56,7 @@ void forceUTAG(const char *rec)
 {
     dbCommon *prec = testdbRecordPtr(rec);
     dbScanLock(prec);
-#ifdef DBR_UTAG
+#if DBR_UTAG
     prec->utag = 42;
 #endif
     dbScanUnlock(prec);
@@ -64,7 +64,7 @@ void forceUTAG(const char *rec)
 
 void checkUTAG(Value& v, int32_t expect=42)
 {
-#ifdef DBR_UTAG
+#if DBR_UTAG
     auto utag = v["timeStamp.userTag"];
     if(!utag.isMarked() || utag.as<int32_t>()!=expect)
         testFail("userTag not set");
@@ -278,7 +278,7 @@ void testGetScalar()
     forceUTAG("test:nsec"); // forced value should be ignored
 
     val = ctxt.get("test:nsec").exec()->wait(5.0);
-#ifdef DBR_UTAG
+#if DBR_UTAG
     testFldEq(val, "timeStamp.userTag", 142);
     val["timeStamp.userTag"].unmark();
 #else


### PR DESCRIPTION
This is a proposal to fix #177 , I think I got it right.
Test case uses a source PV created from pvxs SharedPV with a customized userTag.